### PR TITLE
Fix collapse to only hide rules

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="{ruleset: isRuleset(data), invalid: !config.allowEmptyRulesets && isEmptyRuleset(data)} as local">
   <div [ngClass]="getQueryRulesetClassName(local)">
     <div [ngClass]="getClassNames('switchRow')">
-      <a *ngIf="allowCollapse" (click)="toggleCollapse()" [ngClass]="getClassNames('arrowIconButton', data.collapsed ? 'collapsed' : null)">
+      <a *ngIf="allowCollapse" (click)="toggleCollapse()" [ngClass]="getClassNames('arrowIconButton', collapsed ? 'collapsed' : null)">
         <ng-template [ngTemplateOutlet]="_arrowIconTpl"/>
       </a>
 
@@ -10,7 +10,7 @@
       <ng-template [ngTemplateOutlet]="_buttonGroupTpl"/>
     </div>
 
-    <div [ngClass]="getClassNames('treeContainer', data.collapsed ? 'collapsed' : null)" (transitionend)="transitionEnd()" #treeContainer>
+    <div [ngClass]="getClassNames('treeContainer', collapsed ? 'collapsed' : null)" (transitionend)="transitionEnd()" #treeContainer>
       <ul [ngClass]="getClassNames('tree')" *ngIf="data && data.rules">
         <ng-container *ngFor="let rule of data.rules;let i = index">
           <ng-container *ngIf="!config.rulesLimit || i < config.rulesLimit">

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -145,6 +145,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   @Input() persistValueOnFieldChange = false;
 
   @ViewChild('treeContainer', {static: true}) treeContainer!: ElementRef;
+  public collapsed = false;
 
   @ContentChild(QueryButtonGroupDirective) buttonGroupTemplate!: QueryButtonGroupDirective;
   @ContentChild(QuerySwitchGroupDirective) switchGroupTemplate!: QuerySwitchGroupDirective;
@@ -481,7 +482,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   toggleCollapse(): void {
     this.computedTreeContainerHeight();
     setTimeout(() => {
-      this.data.collapsed = !this.data.collapsed;
+      this.collapsed = !this.collapsed;
     }, 100);
   }
 


### PR DESCRIPTION
## Summary
- track collapsed state in component instead of ruleset data
- update template to use the component's collapsed flag

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68670f9edc6c83218b18d1a24c5b4548