### PR TITLE
Fix demo layout and collapse overflow

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -1,5 +1,11 @@
 <main class="main">
   <div class="content">
+    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [persistValueOnFieldChange]='persistValueOnFieldChange'>
+      <ng-container *queryInput="let rule; type: 'textarea'; let getDisabledState=getDisabledState">
+      <textarea class="text-input text-area" [(ngModel)]="rule.value" [disabled]=getDisabledState()
+                placeholder="Custom Textarea"></textarea>
+      </ng-container>
+    </ngx-query-builder>
     <div class="row panel" style="flex-direction: column">
       <div class="row">
         <label>Control Valid (Vanilla): {{ queryCtrl.valid }}</label>
@@ -25,13 +31,7 @@
         </div>
       </div>
 
-      <textarea class="output">{{query | json}}</textarea>
+    <textarea class="output">{{query | json}}</textarea>
     </div>
-    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [persistValueOnFieldChange]='persistValueOnFieldChange'>
-      <ng-container *queryInput="let rule; type: 'textarea'; let getDisabledState=getDisabledState">
-      <textarea class="text-input text-area" [(ngModel)]="rule.value" [disabled]=getDisabledState()
-                placeholder="Custom Textarea"></textarea>
-      </ng-container>
-    </ngx-query-builder>
   </div>
 </main>

--- a/projects/ngx-query-builder-demo/src/app/app.component.less
+++ b/projects/ngx-query-builder-demo/src/app/app.component.less
@@ -3,12 +3,8 @@
 
   .content {
     display: flex;
+    flex-direction: column;
     gap: 20px;
-    justify-content: center;
-  }
-
-  ngx-query-builder, .panel {
-    flex: 1;
   }
 }
 

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -185,6 +185,7 @@
 
   .q-tree-container {
     width: 100%;
+    overflow: hidden;
     transition: ease-in 0.25s max-height;
 
     &.q-collapsed {


### PR DESCRIPTION
## Summary
- stack demo components vertically so the builder sits above the options panel
- add overflow hidden to the rules container so collapsed sets are hidden

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867143cfb088321bc086d2a7dc6213c