### PR TITLE
Fix build setup for Angular 19

### DIFF
--- a/projects/ngx-query-builder/README.md
+++ b/projects/ngx-query-builder/README.md
@@ -258,7 +258,7 @@ Can be used to customize the default empty warning message, alternatively can sp
 |`getDisabledState`|`() => boolean`| Retrieves or determines the disabled state of the component|
 
 ## Dependencies
-- Angular 18+
+- Angular 19+
 
 # Development
 

--- a/projects/ngx-query-builder/package.json
+++ b/projects/ngx-query-builder/package.json
@@ -11,8 +11,8 @@
   },
   "homepage": "https://github.com/kerwin612/ngx-query-builder",
   "peerDependencies": {
-    "@angular/common": "^18.1.0",
-    "@angular/core": "^18.1.0"
+    "@angular/common": "^19.0.0",
+    "@angular/core": "^19.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -279,7 +279,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
 
   findQueryInput(type: string): QueryInputDirective | undefined {
     const templates = this.parentInputTemplates || this.inputTemplates;
-    return (templates||[]).find((item) => item.queryInputType === type);
+    return (templates || []).find((item: QueryInputDirective) => item.queryInputType === type);
   }
 
   getOperators(field: string): string[] {


### PR DESCRIPTION
## Summary
- update Angular peer dependency to version 19
- update documentation to say Angular 19+
- add missing type in `QueryBuilderComponent`

## Testing
- `npx tsc -p projects/ngx-query-builder/tsconfig.lib.json` *(fails: Cannot find module '@angular/core')*
- `npm install --legacy-peer-deps` *(fails: network access blocked)*
- `npx ng build ngx-query-builder` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6867263e9e6883218fec579440152fa0