### PR TITLE
Fix textarea resize

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.less
+++ b/projects/ngx-query-builder-demo/src/app/app.component.less
@@ -29,5 +29,7 @@
 }
 
 .output {
-  flex: 1;
+  height: 500px;
+  resize: both;
+  overflow: auto;
 }


### PR DESCRIPTION
## Summary
- remove flex constraint on output textarea
- set a default height and enable resize both directions so the page can scroll

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672b75ec3c8321b8a949790cc9d267