### PR TITLE
Add NOT toggle to rulesets

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -75,6 +75,11 @@
 
   <ng-template #defaultSwitchGroup>
     <div [ngClass]="getClassNames('switchGroup', 'transition')" *ngIf="data">
+      <div [ngClass]="getClassNames('switchControl')" *ngIf="enableNot">
+        <input type="checkbox" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.not"
+               (ngModelChange)="changeNot($event)" [disabled]="disabled" />
+        <label (click)="changeNot(!data.not)" [ngClass]="getClassNames('switchLabel')">NOT</label>
+      </div>
       <div [ngClass]="getClassNames('switchControl')">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="and" #andOption />

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -122,6 +122,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   @Input() disabled!: boolean;
   @Input() level = 0;
   @Input() data: RuleSet = { condition: 'and', rules: [] };
+  @Input() enableNot = false;
   @Input() allowRuleset = true;
   @Input() allowCollapse = false;
   @Input() emptyMessage = 'A ruleset cannot be empty. Please add a rule or remove it all together.';
@@ -450,7 +451,11 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     if (this.config.addRuleSet) {
       this.config.addRuleSet(parent);
     } else {
-      parent.rules = parent.rules.concat([{ condition: 'and', rules: [] }]);
+      const rs: RuleSet = { condition: 'and', rules: [] };
+      if (this.enableNot) {
+        rs.not = false;
+      }
+      parent.rules = parent.rules.concat([rs]);
     }
 
     this.handleTouched();
@@ -500,6 +505,16 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     }
 
     this.data.condition = value;
+    this.handleTouched();
+    this.handleDataChange();
+  }
+
+  changeNot(value: boolean): void {
+    if (this.disabled) {
+      return;
+    }
+
+    this.data.not = value;
     this.handleTouched();
     this.handleDataChange();
   }
@@ -759,6 +774,8 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   getSwitchGroupContext(): SwitchGroupContext {
     return {
       onChange: this.changeCondition.bind(this),
+      onChangeNot: this.changeNot.bind(this),
+      enableNot: this.enableNot,
       getDisabledState: this.getDisabledState,
       $implicit: this.data
     };

--- a/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts
+++ b/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts
@@ -1,6 +1,7 @@
 export interface RuleSet {
   condition: string;
   rules: (RuleSet | Rule)[];
+  not?: boolean;
   collapsed?: boolean;
   isChild?: boolean;
 }
@@ -103,6 +104,8 @@ export interface QueryBuilderConfig {
 
 export interface SwitchGroupContext {
   onChange: (conditionValue: string) => void;
+  onChangeNot: (not: boolean) => void;
+  enableNot: boolean;
   getDisabledState: () => boolean;
   $implicit: RuleSet;
 }


### PR DESCRIPTION
## Summary
- support `not` condition in `RuleSet` interface
- allow enabling NOT via new `enableNot` input
- add NOT checkbox to switch group
- pass NOT state in contexts and new rulesets

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686730858b5083218ed91cd97f4fc288