### PR TITLE
Add editable JSON textbox

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -34,7 +34,7 @@
         </div>
       </div>
 
-    <textarea class="output">{{query | json}}</textarea>
+    <textarea class="output" [(ngModel)]="queryText" (ngModelChange)="updateQuery($event)"></textarea>
     </div>
   </div>
 </main>

--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { FormBuilder, FormControl } from '@angular/forms';
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { QueryBuilderClassNames, QueryBuilderConfig } from 'ngx-query-builder';
 
 @Component({
@@ -8,8 +8,9 @@ import { QueryBuilderClassNames, QueryBuilderConfig } from 'ngx-query-builder';
   styleUrls: ['./app.component.less'],
   standalone: false
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   public queryCtrl: FormControl;
+  public queryText: string = '';
 
   public bootstrapClassNames: QueryBuilderClassNames = {
     removeIcon: 'fa fa-minus',
@@ -134,6 +135,22 @@ export class AppComponent {
   ) {
     this.queryCtrl = this.formBuilder.control(this.query);
     this.currentConfig = this.entityConfig;
+    this.queryText = JSON.stringify(this.queryCtrl.value, null, 2);
+  }
+
+  ngOnInit(): void {
+    this.queryCtrl.valueChanges.subscribe(value => {
+      this.queryText = JSON.stringify(value, null, 2);
+    });
+  }
+
+  updateQuery(text: string): void {
+    try {
+      const val = JSON.parse(text);
+      this.queryCtrl.setValue(val);
+    } catch {
+      // ignore invalid JSON
+    }
   }
 
   switchModes(event: Event) {


### PR DESCRIPTION
## Summary
- add two-way binding to query JSON in the demo
- update demo textarea to edit the JSON

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e0d66c28832185160bc8bfa36727