### PR TITLE
Add invalid JSON highlighting

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -34,7 +34,7 @@
         </div>
       </div>
 
-    <textarea class="output" [(ngModel)]="queryText" (ngModelChange)="updateQuery($event)"></textarea>
+    <textarea class="output" [ngClass]="{'invalid': queryTextInvalid}" [(ngModel)]="queryText" (ngModelChange)="updateQuery($event)"></textarea>
     </div>
   </div>
 </main>

--- a/projects/ngx-query-builder-demo/src/app/app.component.less
+++ b/projects/ngx-query-builder-demo/src/app/app.component.less
@@ -33,3 +33,7 @@
   resize: both;
   overflow: auto;
 }
+
+.output.invalid {
+  background-color: #f8d7da;
+}

--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -11,6 +11,7 @@ import { QueryBuilderClassNames, QueryBuilderConfig } from 'ngx-query-builder';
 export class AppComponent implements OnInit {
   public queryCtrl: FormControl;
   public queryText: string = '';
+  public queryTextInvalid = false;
 
   public bootstrapClassNames: QueryBuilderClassNames = {
     removeIcon: 'fa fa-minus',
@@ -136,11 +137,13 @@ export class AppComponent implements OnInit {
     this.queryCtrl = this.formBuilder.control(this.query);
     this.currentConfig = this.entityConfig;
     this.queryText = JSON.stringify(this.queryCtrl.value, null, 2);
+    this.queryTextInvalid = this.queryCtrl.invalid;
   }
 
   ngOnInit(): void {
     this.queryCtrl.valueChanges.subscribe(value => {
       this.queryText = JSON.stringify(value, null, 2);
+      this.queryTextInvalid = this.queryCtrl.invalid;
     });
   }
 
@@ -148,7 +151,9 @@ export class AppComponent implements OnInit {
     try {
       const val = JSON.parse(text);
       this.queryCtrl.setValue(val);
+      this.queryTextInvalid = this.queryCtrl.invalid;
     } catch {
+      this.queryTextInvalid = true;
       // ignore invalid JSON
     }
   }


### PR DESCRIPTION
## Summary
- make the JSON output textarea show errors
- track invalid state in the demo

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run lint --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e9226c3c8321a9a49b6eedf00124