### PR TITLE
Fix JSON validation handling

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -149,10 +149,10 @@ export class AppComponent implements OnInit {
 
   updateQuery(text: string): void {
     try {
-      const val = JSON.parse(text);
+      const val = JSON.parse(text.trim());
       if (this.validateQuery(val)) {
         this.queryCtrl.setValue(val);
-        this.queryTextInvalid = this.queryCtrl.invalid;
+        this.queryTextInvalid = false;
       } else {
         this.queryTextInvalid = true;
       }


### PR DESCRIPTION
## Summary
- fix query validation logic to clear error styling when valid JSON is entered

## Testing
- `npm test` *(fails: ng not found)*
- `npx ng test` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_6867f56a68648321925f0996319483fb