### PR TITLE
Fix category validator for multiselect operators

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -249,8 +249,17 @@ export class AppComponent implements OnInit {
           }
           break;
         case 'category':
-          if (!fieldConf.options || !fieldConf.options.some(o => o.value === val)) {
-            return false;
+          if (rule.operator === 'in' || rule.operator === 'not in') {
+            if (!Array.isArray(val)) {
+              return false;
+            }
+            if (fieldConf.options && val.some((v: any) => !fieldConf.options!.some(o => o.value === v))) {
+              return false;
+            }
+          } else {
+            if (!fieldConf.options || !fieldConf.options.some(o => o.value === val)) {
+              return false;
+            }
           }
           break;
         case 'boolean':


### PR DESCRIPTION
## Summary
- update demo validation logic to handle `in`/`not in` for category fields

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868007ab8b48321816c0da5a139c7ec