### PR TITLE
Fix category validation

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -250,10 +250,13 @@ export class AppComponent implements OnInit {
           break;
         case 'category':
           if (rule.operator === 'in' || rule.operator === 'not in') {
-            if (!Array.isArray(val)) {
+            if (!Array.isArray(val) || val.length === 0) {
               return false;
             }
-            if (fieldConf.options && val.some((v: any) => !fieldConf.options!.some(o => o.value === v))) {
+            if (
+              fieldConf.options &&
+              val.some((v: any) => !fieldConf.options!.some(o => o.value === v))
+            ) {
               return false;
             }
           } else {


### PR DESCRIPTION
## Summary
- disallow an empty array for category attributes in demo validator

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868036887388321ad036c815f96d281