### PR TITLE
Fix textarea updates and default mode

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -1,9 +1,9 @@
 <main class="main">
   <div class="content">
     <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [persistValueOnFieldChange]='persistValueOnFieldChange'>
-      <ng-container *queryInput="let rule; type: 'textarea'; let getDisabledState=getDisabledState">
-      <textarea class="text-input text-area" [(ngModel)]="rule.value" [disabled]=getDisabledState()
-                placeholder="Custom Textarea"></textarea>
+      <ng-container *queryInput="let rule; type: 'textarea'; let onChange=onChange; let getDisabledState=getDisabledState">
+        <textarea class="text-input text-area" [(ngModel)]="rule.value" (ngModelChange)="onChange()" [disabled]="getDisabledState()"
+                  placeholder="Custom Textarea"></textarea>
       </ng-container>
     </ngx-query-builder>
     <div class="row panel" style="flex-direction: column">
@@ -15,7 +15,7 @@
       </div>
       <div class="row">
         <div>
-          <label><input type="checkbox" checked (change)=switchModes($event)>Entity Mode</label>
+          <label><input type="checkbox" (change)="switchModes($event)">Entity Mode</label>
         </div>
         <div>
           <label><input type="checkbox" [(ngModel)]='allowRuleset'>Allow Ruleset</label>

--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -135,7 +135,7 @@ export class AppComponent implements OnInit {
     private formBuilder: FormBuilder
   ) {
     this.queryCtrl = this.formBuilder.control(this.query);
-    this.currentConfig = this.entityConfig;
+    this.currentConfig = this.config;
     this.queryText = JSON.stringify(this.queryCtrl.value, null, 2);
     this.queryTextInvalid = !this.validateQuery(this.queryCtrl.value);
   }


### PR DESCRIPTION
## Summary
- make the demo load without entity mode enabled
- call the query builder change handler in the custom textarea template

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run lint --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686807b2c4bc8321a2b74551a6dfcb36