### PR TITLE
Implement entity cleanup

### DIFF
--- a/projects/ngx-query-builder/README.md
+++ b/projects/ngx-query-builder/README.md
@@ -126,6 +126,7 @@ config: QueryBuilderConfig = {
 |`config.calculateFieldChangeValue`| `(currentField: Field, nextField: Field, currentValue: any) => any`                                                                                                         |Optional|                                  | Used to calculate the new value when a rule's field changes. |
 |`value`| [`Ruleset`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts)                                                                                         |Optional| { condition: 'and', rules: [] }  | Object that stores the state of the component. |
 
+When `config.entities` is not provided, any `entity` properties found in the query are removed from the emitted JSON. If `config.entities` is specified, rules without an `entity` automatically receive the entity from the first matching field.
 ## Structural Directives
 
 Use these directives to replace different parts of query builder with custom components.

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -947,7 +947,8 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   private cleanData(data: RuleSet): RuleSet {
     // Create a deep copy to avoid modifying the original data
     const cleanedData = JSON.parse(JSON.stringify(data));
-    
+    const entityMode = this.entities && this.entities.length > 0;
+
     // Remove 'not' property if allowNot is false
     if (!this.allowNot && cleanedData.hasOwnProperty('not')) {
       delete cleanedData.not;
@@ -955,14 +956,23 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     
     // Recursively clean nested rulesets
     if (cleanedData.rules) {
-      cleanedData.rules = cleanedData.rules.map((rule: Rule | RuleSet) => {
-        if (this.isRuleset(rule)) {
-          return this.cleanData(rule);
+      cleanedData.rules = cleanedData.rules.map((item: Rule | RuleSet) => {
+        if (this.isRuleset(item)) {
+          return this.cleanData(item);
+        }
+        const rule = item as Rule;
+        if (!entityMode && rule.hasOwnProperty('entity')) {
+          delete (rule as any).entity;
+        } else if (entityMode && !rule.entity) {
+          const field = this.fields.find((f) => f.value === rule.field);
+          if (field && field.entity) {
+            rule.entity = field.entity;
+          }
         }
         return rule;
       });
     }
-    
+
     return cleanedData;
   }
 


### PR DESCRIPTION
## Summary
- clean `entity` data when not in entity mode
- infer entity from fields if missing when entity mode is active
- document entity cleanup logic in README

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680b0645c08321b1ee4ae0d032d80b