### PR TITLE
Fix custom input value updates

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -1,8 +1,8 @@
 <main class="main">
   <div class="content">
     <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [persistValueOnFieldChange]='persistValueOnFieldChange'>
-      <ng-container *queryInput="let rule; type: 'textarea'; let getDisabledState=getDisabledState">
-      <textarea class="text-input text-area" [(ngModel)]="rule.value" [disabled]=getDisabledState()
+      <ng-container *queryInput="let rule; type: 'textarea'; let getDisabledState=getDisabledState; let onChange=onChange">
+      <textarea class="text-input text-area" [(ngModel)]="rule.value" (ngModelChange)="onChange()" [disabled]=getDisabledState()
                 placeholder="Custom Textarea"></textarea>
       </ng-container>
     </ngx-query-builder>

--- a/projects/ngx-query-builder/README.md
+++ b/projects/ngx-query-builder/README.md
@@ -84,8 +84,8 @@ export class AppComponent {
 ##### `app.component.html`
 ```html
 <ngx-query-builder [(ngModel)]='query' [config]='config'>
-  <ng-container *queryInput="let rule; type: 'date'">
-    <custom-datepicker [(ngModel)]="rule.value"></custom-datepicker>
+  <ng-container *queryInput="let rule; type: 'date'; let onChange=onChange">
+    <custom-datepicker [(ngModel)]="rule.value" (ngModelChange)="onChange()"></custom-datepicker>
   </ng-container>
 </ngx-query-builder>
 ```


### PR DESCRIPTION
## Summary
- ensure custom textarea input notifies the query builder on value changes
- document calling `onChange()` when providing custom inputs

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68689d698b84832193b832352e356d88