### PR TITLE
Fix tree refresh when external JSON updates

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.spec.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.spec.ts
@@ -24,4 +24,13 @@ describe('QueryBuilderComponent', () => {
   it('should be created', () => {
     expect(component).toBeTruthy();
   });
+
+  it('updates when input data changes', () => {
+    const initial = { condition: 'and', rules: [{ field: 'age', operator: '=' }] } as any;
+    component.value = initial;
+    const updated = { condition: 'and', rules: [] } as any;
+    component.data = updated;
+    component.ngOnChanges({ data: { previousValue: initial, currentValue: updated, firstChange: false, isFirstChange: () => false } } as any);
+    expect(component.value.rules.length).toBe(0);
+  });
 });

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -179,6 +179,18 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   private ruleRemoveButtonContextCache = new Map<Rule, RuleRemoveButtonContext>();
   private buttonGroupContext!: ButtonGroupContext;
 
+  private clearContextCaches(): void {
+    this.inputContextCache.clear();
+    this.operatorContextCache.clear();
+    this.fieldContextCache.clear();
+    this.entityContextCache.clear();
+    this.rulesetAddRuleButtonContextCache.clear();
+    this.rulesetAddRulesetButtonContextCache.clear();
+    this.rulesetRemoveButtonContextCache.clear();
+    this.ruleRemoveButtonContextCache.clear();
+    this.buttonGroupContext = undefined as any;
+  }
+
   constructor(private changeDetectorRef: ChangeDetectorRef) { }
 
   // ----------OnChanges Implementation----------
@@ -208,9 +220,10 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
       throw new Error(`Expected 'config' must be a valid object, got ${type} instead.`);
     }
 
-    // Handle allowNot changes
-    if (changes['allowNot']) {
+    // Handle allowNot or data changes
+    if (changes['allowNot'] || changes['data']) {
       this.updateNotProperty(this.data, this.allowNot);
+      this.clearContextCaches();
       this.handleDataChange();
     }
   }


### PR DESCRIPTION
## Summary
- clear context caches on external data changes
- update caches and not flag when ruleset input changes
- add unit test for input updates

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868a0324ee88321bddf0b19c8c68b4c