### PR TITLE
Handle invalid JSON in demo editor

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -34,7 +34,7 @@
         </div>
       </div>
 
-    <textarea class="output" [ngClass]="{'invalid': queryTextInvalid}" [(ngModel)]="queryText" (ngModelChange)="updateQuery($event)"></textarea>
+    <textarea class="output" [title]="queryTitle" [ngClass]="queryTextState" [(ngModel)]="queryText" (ngModelChange)="updateQuery($event)"></textarea>
     </div>
   </div>
 </main>

--- a/projects/ngx-query-builder-demo/src/app/app.component.less
+++ b/projects/ngx-query-builder-demo/src/app/app.component.less
@@ -34,6 +34,10 @@
   overflow: auto;
 }
 
-.output.invalid {
+.output.invalid-query {
   background-color: #f8d7da;
+}
+
+.output.invalid-json {
+  background-color: #f2bcbc;
 }

--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -11,7 +11,8 @@ import { QueryBuilderClassNames, QueryBuilderConfig } from 'ngx-query-builder';
 export class AppComponent implements OnInit {
   public queryCtrl: FormControl;
   public queryText: string = '';
-  public queryTextInvalid = false;
+  public queryTextState: 'valid' | 'invalid-json' | 'invalid-query' = 'valid';
+  public queryTitle = '';
 
   public bootstrapClassNames: QueryBuilderClassNames = {
     removeIcon: 'fa fa-minus',
@@ -137,13 +138,25 @@ export class AppComponent implements OnInit {
     this.queryCtrl = this.formBuilder.control(this.query);
     this.currentConfig = this.config;
     this.queryText = JSON.stringify(this.queryCtrl.value, null, 2);
-    this.queryTextInvalid = !this.validateQuery(this.queryCtrl.value);
+    if (this.validateQuery(this.queryCtrl.value)) {
+      this.queryTextState = 'valid';
+      this.queryTitle = '';
+    } else {
+      this.queryTextState = 'invalid-query';
+      this.queryTitle = 'Invalid query';
+    }
   }
 
   ngOnInit(): void {
     this.queryCtrl.valueChanges.subscribe(value => {
       this.queryText = JSON.stringify(value, null, 2);
-      this.queryTextInvalid = !this.validateQuery(value);
+      if (this.validateQuery(value)) {
+        this.queryTextState = 'valid';
+        this.queryTitle = '';
+      } else {
+        this.queryTextState = 'invalid-query';
+        this.queryTitle = 'Invalid query';
+      }
     });
   }
 
@@ -152,12 +165,15 @@ export class AppComponent implements OnInit {
       const val = JSON.parse(text.trim());
       if (this.validateQuery(val)) {
         this.queryCtrl.setValue(val);
-        this.queryTextInvalid = false;
+        this.queryTextState = 'valid';
+        this.queryTitle = '';
       } else {
-        this.queryTextInvalid = true;
+        this.queryTextState = 'invalid-query';
+        this.queryTitle = 'Invalid query';
       }
     } catch {
-      this.queryTextInvalid = true;
+      this.queryTextState = 'invalid-json';
+      this.queryTitle = 'Invalid JSON';
       // ignore invalid JSON
     }
   }


### PR DESCRIPTION
## Summary
- improve JSON editor handling in demo
- show different messages for invalid JSON vs invalid query
- style textarea to show validation state

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869403f22708321bcfed0103769054d