### PR TITLE
Add convert-to-ruleset button

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -30,6 +30,9 @@
                   </div>
 
                   <div [ngClass]="getClassNames('ruleActions')">
+                    <button type="button" (click)="convertToRuleset(rule, data)" [ngClass]="getClassNames('button')" [disabled]="disabled">
+                      <i [ngClass]="getClassNames('addIcon')"></i> Convert to Ruleset
+                    </button>
                     <ng-template [ngTemplateOutlet]="_ruleRemoveButtonTpl" [ngTemplateOutletContext]="{ $implicit: rule }"/>
                   </div>
                 </div>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -462,6 +462,35 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     this.handleDataChange();
   }
 
+  convertToRuleset(rule: Rule, parent?: RuleSet): void {
+    if (this.disabled) {
+      return;
+    }
+
+    parent = parent || this.data;
+    const index = parent.rules.indexOf(rule);
+    if (index === -1) {
+      return;
+    }
+
+    const newRule: Rule = { ...rule };
+    const rs: RuleSet = { condition: 'or', rules: [newRule] };
+    if (this.allowNot) {
+      rs.not = false;
+    }
+
+    parent.rules.splice(index, 1, rs);
+
+    this.inputContextCache.delete(rule);
+    this.operatorContextCache.delete(rule);
+    this.fieldContextCache.delete(rule);
+    this.entityContextCache.delete(rule);
+    this.ruleRemoveButtonContextCache.delete(rule);
+
+    this.handleTouched();
+    this.handleDataChange();
+  }
+
   addRuleSet(parent?: RuleSet): void {
     if (this.disabled) {
       return;


### PR DESCRIPTION
## Summary
- add a `Convert to Ruleset` button next to each rule's delete action
- replace the rule with a new OR ruleset when clicked

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694a43994483218a9a8cd5d32de373