### PR TITLE
Implement convert ruleset toggle and textarea validation

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -1,6 +1,6 @@
 <main class="main">
   <div class="content">
-    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [persistValueOnFieldChange]='persistValueOnFieldChange'>
+    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [allowConvertToRuleset]='allowConvertToRuleset' [persistValueOnFieldChange]='persistValueOnFieldChange'>
       <ng-container *queryInput="let rule; type: 'textarea'; let getDisabledState=getDisabledState; let onChange=onChange">
       <textarea class="text-input text-area" [(ngModel)]="rule.value" (ngModelChange)="onChange()" [disabled]=getDisabledState()
                 placeholder="Custom Textarea"></textarea>
@@ -28,6 +28,9 @@
         </div>
         <div>
           <label><input type="checkbox" [(ngModel)]='persistValueOnFieldChange'>Persist Values on Field Change</label>
+        </div>
+        <div>
+          <label><input type="checkbox" [(ngModel)]='allowConvertToRuleset'>Allow Convert To Ruleset</label>
         </div>
         <div>
           <label><input type="checkbox" (change)=changeDisabled($event)>Disabled</label>

--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -130,6 +130,7 @@ export class AppComponent implements OnInit {
   public allowRuleset: boolean = true;
   public allowCollapse: boolean = false;
   public allowNot: boolean = false;
+  public allowConvertToRuleset: boolean = true;
   public persistValueOnFieldChange: boolean = false;
 
   constructor(

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -30,8 +30,8 @@
                   </div>
 
                   <div [ngClass]="getClassNames('ruleActions')">
-                    <button type="button" (click)="convertToRuleset(rule, data)" [ngClass]="getClassNames('button')" [disabled]="disabled">
-                      <i [ngClass]="getClassNames('addIcon')"></i> Convert to Ruleset
+                    <button *ngIf="allowConvertToRuleset" type="button" (click)="convertToRuleset(rule, data)" [ngClass]="getClassNames('button')" [disabled]="disabled">
+                      Convert to Ruleset
                     </button>
                     <ng-template [ngTemplateOutlet]="_ruleRemoveButtonTpl" [ngTemplateOutletContext]="{ $implicit: rule }"/>
                   </div>
@@ -49,7 +49,8 @@
                                  [parentRuleRemoveButtonTemplate]="parentRuleRemoveButtonTemplate || ruleRemoveButtonTemplate"
                                  [parentEmptyWarningTemplate]="parentEmptyWarningTemplate || emptyWarningTemplate" [parentArrowIconTemplate]="parentArrowIconTemplate || arrowIconTemplate"
                                  [parentValue]="data" [classNames]="classNames" [config]="config" [allowRuleset]="allowRuleset"
-                                 [allowCollapse]="allowCollapse" [allowNot]="allowNot" [emptyMessage]="emptyMessage" [operatorMap]="operatorMap">
+                                 [allowCollapse]="allowCollapse" [allowNot]="allowNot" [allowConvertToRuleset]="allowConvertToRuleset"
+                                 [emptyMessage]="emptyMessage" [operatorMap]="operatorMap">
               </ngx-query-builder>
             </li>
           </ng-container>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -125,6 +125,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   @Input() data: RuleSet = { condition: 'and', rules: [] };
   @Input() allowNot = false;
   @Input() allowRuleset = true;
+  @Input() allowConvertToRuleset = true;
   @Input() allowCollapse = false;
   @Input() emptyMessage = 'A ruleset cannot be empty. Please add a rule or remove it all together.';
   @Input() classNames!: QueryBuilderClassNames;
@@ -937,6 +938,12 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
             const error = field.validator(item as Rule, ruleset);
             if (error != null) {
               errorStore.push(error);
+            }
+          } else if (field && field.type === 'textarea') {
+            const rule = item as Rule;
+            const requiresValue = rule.operator !== 'is null' && rule.operator !== 'is not null';
+            if (requiresValue && (typeof rule.value !== 'string' || rule.value.trim() === '')) {
+              errorStore.push({ field: rule.field, error: 'required' });
             }
           }
         }


### PR DESCRIPTION
## Summary
- allow hiding Convert to Ruleset button with new `allowConvertToRuleset` input
- remove plus icon from the Convert to Ruleset button
- treat empty textarea values as invalid
- demo: expose convert toggle checkbox

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696556745883219e005e6119ac69c0