### PR TITLE
Remove Convert to Ruleset feature

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -1,6 +1,6 @@
 <main class="main">
   <div class="content">
-    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [allowConvertToRuleset]='allowConvertToRuleset' [persistValueOnFieldChange]='persistValueOnFieldChange'>
+    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [persistValueOnFieldChange]='persistValueOnFieldChange'>
       <ng-container *queryInput="let rule; type: 'textarea'; let getDisabledState=getDisabledState; let onChange=onChange">
       <textarea class="text-input text-area" [(ngModel)]="rule.value" (ngModelChange)="onChange()" [disabled]=getDisabledState()
                 placeholder="Custom Textarea"></textarea>
@@ -28,9 +28,6 @@
         </div>
         <div>
           <label><input type="checkbox" [(ngModel)]='persistValueOnFieldChange'>Persist Values on Field Change</label>
-        </div>
-        <div>
-          <label><input type="checkbox" [(ngModel)]='allowConvertToRuleset'>Allow Convert To Ruleset</label>
         </div>
         <div>
           <label><input type="checkbox" (change)=changeDisabled($event)>Disabled</label>

--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -130,7 +130,6 @@ export class AppComponent implements OnInit {
   public allowRuleset: boolean = true;
   public allowCollapse: boolean = true;
   public allowNot: boolean = false;
-  public allowConvertToRuleset: boolean = false;
   public persistValueOnFieldChange: boolean = false;
 
   constructor(

--- a/projects/ngx-query-builder/README.md
+++ b/projects/ngx-query-builder/README.md
@@ -115,7 +115,6 @@ config: QueryBuilderConfig = {
 |:--- |:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--- |:---------------------------------|:--- |
 |`allowRuleset`| `boolean`                                                                                                                                                                   |Optional| `true`                           | Displays the `+ Ruleset` button if `true`. |
 |`allowCollapse`| `boolean` |Optional| `true`                          | Enables collapsible rule sets if `true`.  |
-|`allowConvertToRuleset`| `boolean` |Optional| `false`                          | Displays the `Convert to Ruleset` button if `true`. |
 |`allowNot`| `boolean` |Optional| `false`                          | Adds a `NOT` button and sets a `not` attribute on the ruleset JSON. |
 |`classNames`| [`QueryBuilderClassNames`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L48)                                                                      |Optional|                                  | CSS class names for different child elements in `query-builder` component. |
 |`config`| [`QueryBuilderConfig`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L85)                                                                          |Required|                                  | Configuration object for the main component. |

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -30,9 +30,6 @@
                   </div>
 
                   <div [ngClass]="getClassNames('ruleActions')">
-                    <button *ngIf="allowConvertToRuleset" type="button" (click)="convertToRuleset(rule, data)" [ngClass]="getClassNames('button')" [disabled]="disabled">
-                      Convert to Ruleset
-                    </button>
                     <ng-template [ngTemplateOutlet]="_ruleRemoveButtonTpl" [ngTemplateOutletContext]="{ $implicit: rule }"/>
                   </div>
                 </div>
@@ -49,7 +46,7 @@
                                  [parentRuleRemoveButtonTemplate]="parentRuleRemoveButtonTemplate || ruleRemoveButtonTemplate"
                                  [parentEmptyWarningTemplate]="parentEmptyWarningTemplate || emptyWarningTemplate" [parentArrowIconTemplate]="parentArrowIconTemplate || arrowIconTemplate"
                                  [parentValue]="data" [classNames]="classNames" [config]="config" [allowRuleset]="allowRuleset"
-                                 [allowCollapse]="allowCollapse" [allowNot]="allowNot" [allowConvertToRuleset]="allowConvertToRuleset"
+                                 [allowCollapse]="allowCollapse" [allowNot]="allowNot"
                                  [emptyMessage]="emptyMessage" [operatorMap]="operatorMap">
               </ngx-query-builder>
             </li>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -125,7 +125,6 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   @Input() data: RuleSet = { condition: 'and', rules: [] };
   @Input() allowNot = false;
   @Input() allowRuleset = true;
-  @Input() allowConvertToRuleset = false;
   @Input() allowCollapse = true;
   @Input() emptyMessage = 'A ruleset cannot be empty. Please add a rule or remove it all together.';
   @Input() classNames!: QueryBuilderClassNames;
@@ -463,34 +462,6 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     this.handleDataChange();
   }
 
-  convertToRuleset(rule: Rule, parent?: RuleSet): void {
-    if (this.disabled) {
-      return;
-    }
-
-    parent = parent || this.data;
-    const index = parent.rules.indexOf(rule);
-    if (index === -1) {
-      return;
-    }
-
-    const newRule: Rule = { ...rule };
-    const rs: RuleSet = { condition: 'or', rules: [newRule] };
-    if (this.allowNot) {
-      rs.not = false;
-    }
-
-    parent.rules.splice(index, 1, rs);
-
-    this.inputContextCache.delete(rule);
-    this.operatorContextCache.delete(rule);
-    this.fieldContextCache.delete(rule);
-    this.entityContextCache.delete(rule);
-    this.ruleRemoveButtonContextCache.delete(rule);
-
-    this.handleTouched();
-    this.handleDataChange();
-  }
 
   addRuleSet(parent?: RuleSet): void {
     if (this.disabled) {


### PR DESCRIPTION
## Summary
- clean up misinterpreted feature
- remove `convertToRuleset` control and property
- keep textarea validation for empty values

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696db6bcbc8321ad6ba244e54246bf