### PR TITLE
Validate date fields reject datetimes

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -261,7 +261,20 @@ export class AppComponent implements OnInit {
           }
           break;
         case 'date':
-          if (!(val instanceof Date) && (typeof val !== 'string' || isNaN(Date.parse(val)))) {
+          if (val instanceof Date) {
+            if (
+              val.getHours() !== 0 ||
+              val.getMinutes() !== 0 ||
+              val.getSeconds() !== 0 ||
+              val.getMilliseconds() !== 0
+            ) {
+              return false;
+            }
+          } else if (typeof val === 'string') {
+            if (!/^\d{4}-\d{2}-\d{2}$/.test(val) || isNaN(Date.parse(val))) {
+              return false;
+            }
+          } else {
             return false;
           }
           break;


### PR DESCRIPTION
## Summary
- tighten validation rules for `date` fields in demo app

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686971e420688321981e43a34fb1f1cb