### PR TITLE
Add ruleset to rule conversion

### DIFF
--- a/projects/ngx-query-builder/README.md
+++ b/projects/ngx-query-builder/README.md
@@ -115,7 +115,8 @@ config: QueryBuilderConfig = {
 |:--- |:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--- |:---------------------------------|:--- |
 |`allowRuleset`| `boolean`                                                                                                                                                                   |Optional| `true`                           | Displays the `+ Ruleset` button if `true`. |
 |`allowCollapse`| `boolean` |Optional| `true`                          | Enables collapsible rule sets if `true`.  |
-|`allowConvertToRuleset`| `boolean` |Optional| `false`                          | Displays the `Convert to Ruleset` button if `true`. |
+|`allowConvertToRuleset`| `boolean` |Optional| `false`
+| Displays the `Convert to Ruleset` button if `true`. When a rule is the only entry in its parent ruleset, this also shows a `Convert Ruleset to Rule` button. |
 |`allowNot`| `boolean` |Optional| `false`                          | Adds a `NOT` button and sets a `not` attribute on the ruleset JSON. |
 |`classNames`| [`QueryBuilderClassNames`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L48)                                                                      |Optional|                                  | CSS class names for different child elements in `query-builder` component. |
 |`config`| [`QueryBuilderConfig`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L85)                                                                          |Required|                                  | Configuration object for the main component. |

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -33,6 +33,9 @@
                     <button *ngIf="allowConvertToRuleset" type="button" (click)="convertToRuleset(rule, data)" [ngClass]="getClassNames('button')" [disabled]="disabled">
                       Convert to Ruleset
                     </button>
+                    <button *ngIf="allowConvertToRuleset && parentValue && data.rules.length === 1" type="button" (click)="convertRulesetToRule(rule, data, parentValue)" [ngClass]="getClassNames('button')" [disabled]="disabled">
+                      Convert Ruleset to Rule
+                    </button>
                     <ng-template [ngTemplateOutlet]="_ruleRemoveButtonTpl" [ngTemplateOutletContext]="{ $implicit: rule }"/>
                   </div>
                 </div>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -492,6 +492,28 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     this.handleDataChange();
   }
 
+  convertRulesetToRule(rule: Rule, parent?: RuleSet, grandParent?: RuleSet): void {
+    if (this.disabled) {
+      return;
+    }
+
+    parent = parent || this.data;
+    grandParent = grandParent || this.parentValue;
+    if (!grandParent) {
+      return;
+    }
+
+    const index = grandParent.rules.indexOf(parent);
+    if (index === -1) {
+      return;
+    }
+
+    grandParent.rules.splice(index, 1, rule);
+
+    this.handleTouched();
+    this.handleDataChange();
+  }
+
   addRuleSet(parent?: RuleSet): void {
     if (this.disabled) {
       return;


### PR DESCRIPTION
## Summary
- add `convertRulesetToRule` handler to component
- show **Convert Ruleset to Rule** button when parent ruleset has one rule
- document convert button behaviour

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686974da160483219ae1b1eafa7b9d8e