### PR TITLE
Fix convert ruleset to rule placement

### DIFF
--- a/projects/ngx-query-builder/README.md
+++ b/projects/ngx-query-builder/README.md
@@ -116,7 +116,7 @@ config: QueryBuilderConfig = {
 |`allowRuleset`| `boolean`                                                                                                                                                                   |Optional| `true`                           | Displays the `+ Ruleset` button if `true`. |
 |`allowCollapse`| `boolean` |Optional| `true`                          | Enables collapsible rule sets if `true`.  |
 |`allowConvertToRuleset`| `boolean` |Optional| `false`
-| Displays the `Convert to Ruleset` button if `true`. When a rule is the only entry in its parent ruleset, this also shows a `Convert Ruleset to Rule` button. |
+| Displays the `Convert to Ruleset` button if `true`. Rulesets with a single entry also show a `Convert Ruleset to Rule` button (except the root ruleset). |
 |`allowNot`| `boolean` |Optional| `false`                          | Adds a `NOT` button and sets a `not` attribute on the ruleset JSON. |
 |`classNames`| [`QueryBuilderClassNames`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L48)                                                                      |Optional|                                  | CSS class names for different child elements in `query-builder` component. |
 |`config`| [`QueryBuilderConfig`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L85)                                                                          |Required|                                  | Configuration object for the main component. |

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -33,9 +33,6 @@
                     <button *ngIf="allowConvertToRuleset" type="button" (click)="convertToRuleset(rule, data)" [ngClass]="getClassNames('button')" [disabled]="disabled">
                       Convert to Ruleset
                     </button>
-                    <button *ngIf="allowConvertToRuleset && parentValue && data.rules.length === 1" type="button" (click)="convertRulesetToRule(rule, data, parentValue)" [ngClass]="getClassNames('button')" [disabled]="disabled">
-                      Convert Ruleset to Rule
-                    </button>
                     <ng-template [ngTemplateOutlet]="_ruleRemoveButtonTpl" [ngTemplateOutletContext]="{ $implicit: rule }"/>
                   </div>
                 </div>
@@ -120,6 +117,10 @@
       <ng-container *ngIf="!!parentValue && allowRuleset">
         <ng-container *ngTemplateOutlet="_rulesetRemoveButtonTpl"></ng-container>
       </ng-container>
+      <button *ngIf="allowConvertToRuleset && parentValue && data.rules.length === 1" type="button"
+              (click)="convertRulesetToRule(data, parentValue)" [ngClass]="getClassNames('button')" [disabled]="disabled">
+        Convert Ruleset to Rule
+      </button>
     </div>
   </ng-template>
 </ng-template>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -492,23 +492,23 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     this.handleDataChange();
   }
 
-  convertRulesetToRule(rule: Rule, parent?: RuleSet, grandParent?: RuleSet): void {
+  convertRulesetToRule(ruleset?: RuleSet, parent?: RuleSet): void {
     if (this.disabled) {
       return;
     }
 
-    parent = parent || this.data;
-    grandParent = grandParent || this.parentValue;
-    if (!grandParent) {
+    ruleset = ruleset || this.data;
+    parent = parent || this.parentValue;
+    if (!parent || !ruleset) {
       return;
     }
 
-    const index = grandParent.rules.indexOf(parent);
-    if (index === -1) {
+    const index = parent.rules.indexOf(ruleset);
+    if (index === -1 || !ruleset.rules || ruleset.rules.length !== 1) {
       return;
     }
 
-    grandParent.rules.splice(index, 1, rule);
+    parent.rules.splice(index, 1, ruleset.rules[0]);
 
     this.handleTouched();
     this.handleDataChange();


### PR DESCRIPTION
## Summary
- move the "Convert Ruleset to Rule" button from the rule to the parent ruleset when it only contains one item
- ensure the button appears only on nested rulesets
- update implementation and README accordingly

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686978c371d4832183ee6d6e3c599ec1