### PR TITLE
Add rule move up/down feature

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -1,6 +1,6 @@
 <main class="main">
   <div class="content">
-    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [allowConvertToRuleset]='allowConvertToRuleset' [persistValueOnFieldChange]='persistValueOnFieldChange'>
+    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [allowConvertToRuleset]='allowConvertToRuleset' [allowRuleUpDown]='allowRuleUpDown' [persistValueOnFieldChange]='persistValueOnFieldChange'>
       <ng-container *queryInput="let rule; type: 'textarea'; let getDisabledState=getDisabledState; let onChange=onChange">
       <textarea class="text-input text-area" [(ngModel)]="rule.value" (ngModelChange)="onChange()" [disabled]=getDisabledState()
                 placeholder="Custom Textarea"></textarea>
@@ -31,6 +31,9 @@
         </div>
         <div>
           <label><input type="checkbox" [(ngModel)]='allowConvertToRuleset'>Allow Convert To Ruleset</label>
+        </div>
+        <div>
+          <label><input type="checkbox" [(ngModel)]='allowRuleUpDown'>Allow Rule Up/Down</label>
         </div>
         <div>
           <label><input type="checkbox" (change)=changeDisabled($event)>Disabled</label>

--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -131,6 +131,7 @@ export class AppComponent implements OnInit {
   public allowCollapse: boolean = true;
   public allowNot: boolean = false;
   public allowConvertToRuleset: boolean = false;
+  public allowRuleUpDown: boolean = false;
   public persistValueOnFieldChange: boolean = false;
 
   constructor(

--- a/projects/ngx-query-builder/README.md
+++ b/projects/ngx-query-builder/README.md
@@ -117,6 +117,7 @@ config: QueryBuilderConfig = {
 |`allowCollapse`| `boolean` |Optional| `true`                          | Enables collapsible rule sets if `true`.  |
 |`allowConvertToRuleset`| `boolean` |Optional| `false`
 | Displays the `Convert to Ruleset` button if `true`. Rulesets with a single entry also show a `Convert Ruleset to Rule` button (except the root ruleset). |
+|`allowRuleUpDown`| `boolean` |Optional| `false` | Displays up and down arrows on rules for reordering. |
 |`allowNot`| `boolean` |Optional| `false`                          | Adds a `NOT` button and sets a `not` attribute on the ruleset JSON. |
 |`classNames`| [`QueryBuilderClassNames`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L48)                                                                      |Optional|                                  | CSS class names for different child elements in `query-builder` component. |
 |`config`| [`QueryBuilderConfig`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L85)                                                                          |Required|                                  | Configuration object for the main component. |

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -25,6 +25,18 @@
     }
   }
 
+  .q-up-icon {
+    &::before {
+      content: '⬆';
+    }
+  }
+
+  .q-down-icon {
+    &::before {
+      content: '⬇';
+    }
+  }
+
   .q-arrow-icon {
     &::before {
       content: '▶'

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -30,6 +30,16 @@
                   </div>
 
                   <div [ngClass]="getClassNames('ruleActions')">
+                    <button *ngIf="allowRuleUpDown && data.rules.length > 1" type="button" (click)="moveRuleUp(rule, data)"
+                            [ngClass]="getClassNames('button')"
+                            [disabled]="disabled || i === 0">
+                      <i [ngClass]="getClassNames('upIcon')"></i>
+                    </button>
+                    <button *ngIf="allowRuleUpDown && data.rules.length > 1" type="button" (click)="moveRuleDown(rule, data)"
+                            [ngClass]="getClassNames('button')"
+                            [disabled]="disabled || i === data.rules.length - 1">
+                      <i [ngClass]="getClassNames('downIcon')"></i>
+                    </button>
                     <button *ngIf="allowConvertToRuleset" type="button" (click)="convertToRuleset(rule, data)" [ngClass]="getClassNames('button')" [disabled]="disabled">
                       Convert to Ruleset
                     </button>
@@ -50,6 +60,7 @@
                                  [parentEmptyWarningTemplate]="parentEmptyWarningTemplate || emptyWarningTemplate" [parentArrowIconTemplate]="parentArrowIconTemplate || arrowIconTemplate"
                                  [parentValue]="data" [classNames]="classNames" [config]="config" [allowRuleset]="allowRuleset"
                                  [allowCollapse]="allowCollapse" [allowNot]="allowNot" [allowConvertToRuleset]="allowConvertToRuleset"
+                                 [allowRuleUpDown]="allowRuleUpDown"
                                  [emptyMessage]="emptyMessage" [operatorMap]="operatorMap">
               </ngx-query-builder>
             </li>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -105,7 +105,9 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     operatorControl: 'q-operator-control',
     operatorControlSize: 'q-control-size',
     inputControl: 'q-input-control',
-    inputControlSize: 'q-control-size'
+    inputControlSize: 'q-control-size',
+    upIcon: 'q-icon q-up-icon',
+    downIcon: 'q-icon q-down-icon'
   };
   public defaultOperatorMap: Record<string, string[]> = {
     string: ['=', '!=', 'contains', 'like'],
@@ -127,6 +129,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   @Input() allowRuleset = true;
   @Input() allowConvertToRuleset = false;
   @Input() allowCollapse = true;
+  @Input() allowRuleUpDown = false;
   @Input() emptyMessage = 'A ruleset cannot be empty. Please add a rule or remove it all together.';
   @Input() classNames!: QueryBuilderClassNames;
   @Input() operatorMap!: Record<string, string[]>;
@@ -458,6 +461,32 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     this.fieldContextCache.delete(rule);
     this.entityContextCache.delete(rule);
     this.ruleRemoveButtonContextCache.delete(rule);
+
+    this.handleTouched();
+    this.handleDataChange();
+  }
+
+  moveRuleUp(rule: Rule | RuleSet, parent?: RuleSet): void {
+    this.moveRule(rule, parent, -1);
+  }
+
+  moveRuleDown(rule: Rule | RuleSet, parent?: RuleSet): void {
+    this.moveRule(rule, parent, 1);
+  }
+
+  private moveRule(rule: Rule | RuleSet, parent: RuleSet | undefined, step: number): void {
+    if (this.disabled) {
+      return;
+    }
+
+    parent = parent || this.data;
+    const index = parent.rules.indexOf(rule);
+    const newIndex = index + step;
+    if (index === -1 || newIndex < 0 || newIndex >= parent.rules.length) {
+      return;
+    }
+    parent.rules.splice(index, 1);
+    parent.rules.splice(newIndex, 0, rule);
 
     this.handleTouched();
     this.handleDataChange();

--- a/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts
+++ b/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts
@@ -81,6 +81,8 @@ export interface QueryBuilderClassNames {
   operatorControlSize?: string;
   inputControl?: string;
   inputControlSize?: string;
+  upIcon?: string;
+  downIcon?: string;
 }
 
 export interface QueryBuilderConfig {


### PR DESCRIPTION
## Summary
- support new `allowRuleUpDown` option
- add up/down arrow buttons for moving rules
- expose icons in `QueryBuilderClassNames`
- wire demo controls for rule moving
- document `allowRuleUpDown`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697c012ec88321a2139602b8e2863d