### PR TITLE
Add ruleset reordering arrows

### DIFF
--- a/projects/ngx-query-builder/README.md
+++ b/projects/ngx-query-builder/README.md
@@ -117,7 +117,7 @@ config: QueryBuilderConfig = {
 |`allowCollapse`| `boolean` |Optional| `true`                          | Enables collapsible rule sets if `true`.  |
 |`allowConvertToRuleset`| `boolean` |Optional| `false`
 | Displays the `Convert to Ruleset` button if `true`. Rulesets with a single entry also show a `Convert Ruleset to Rule` button (except the root ruleset). |
-|`allowRuleUpDown`| `boolean` |Optional| `false` | Displays up and down arrows on rules for reordering. |
+|`allowRuleUpDown`| `boolean` |Optional| `false` | Displays up and down arrows on rules and nested rulesets for reordering. |
 |`allowNot`| `boolean` |Optional| `false`                          | Adds a `NOT` button and sets a `not` attribute on the ruleset JSON. |
 |`classNames`| [`QueryBuilderClassNames`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L48)                                                                      |Optional|                                  | CSS class names for different child elements in `query-builder` component. |
 |`config`| [`QueryBuilderConfig`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L85)                                                                          |Required|                                  | Configuration object for the main component. |

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -27,13 +27,13 @@
 
   .q-up-icon {
     &::before {
-      content: '⬆';
+      content: '▲';
     }
   }
 
   .q-down-icon {
     &::before {
-      content: '⬇';
+      content: '▼';
     }
   }
 

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -125,6 +125,16 @@
           <ng-container *ngTemplateOutlet="_rulesetAddRulesetButtonTpl"></ng-container>
         </ng-container>
       </ng-container>
+      <ng-container *ngIf="allowRuleUpDown && parentValue && parentValue.rules.length > 1">
+        <button type="button" (click)="moveRuleUp(data, parentValue)" [ngClass]="getClassNames('button')"
+                [disabled]="disabled || parentValue.rules[0] === data">
+          <i [ngClass]="getClassNames('upIcon')"></i>
+        </button>
+        <button type="button" (click)="moveRuleDown(data, parentValue)" [ngClass]="getClassNames('button')"
+                [disabled]="disabled || parentValue.rules[parentValue.rules.length - 1] === data">
+          <i [ngClass]="getClassNames('downIcon')"></i>
+        </button>
+      </ng-container>
       <ng-container *ngIf="!!parentValue && allowRuleset">
         <ng-container *ngTemplateOutlet="_rulesetRemoveButtonTpl"></ng-container>
       </ng-container>


### PR DESCRIPTION
## Summary
- allow moving of rulesets using up/down arrows
- use thicker ▲/▼ icons for move buttons
- document new ruleset arrow behavior

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697f4052e0832181b15a1ff39d4a4a