### PR TITLE
Fix convert button order

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -135,13 +135,13 @@
           <i [ngClass]="getClassNames('downIcon')"></i>
         </button>
       </ng-container>
-      <ng-container *ngIf="!!parentValue && allowRuleset">
-        <ng-container *ngTemplateOutlet="_rulesetRemoveButtonTpl"></ng-container>
-      </ng-container>
       <button *ngIf="allowConvertToRuleset && parentValue && data.rules.length === 1" type="button"
               (click)="convertRulesetToRule(data, parentValue)" [ngClass]="getClassNames('button')" [disabled]="disabled">
         Convert to Rule
       </button>
+      <ng-container *ngIf="!!parentValue && allowRuleset">
+        <ng-container *ngTemplateOutlet="_rulesetRemoveButtonTpl"></ng-container>
+      </ng-container>
     </div>
   </ng-template>
 </ng-template>


### PR DESCRIPTION
## Summary
- reorder 'Convert to Rule' button before the delete button so that it appears to the left

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869830ead808321a53a389d9daae3c3