### PR TITLE
Add collapsed summary callback

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -24,6 +24,9 @@
           <label><input type="checkbox" [(ngModel)]='allowCollapse'>Allow Collapse</label>
         </div>
         <div>
+          <label><input type="checkbox" [(ngModel)]='useCollapsedSummary' (change)='updateCollapsedSummary()'>Collapsed Summary</label>
+        </div>
+        <div>
           <label><input type="checkbox" [(ngModel)]='allowNot'>Allow Not</label>
         </div>
         <div>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -254,4 +254,9 @@
     display: inline-block;
     vertical-align: top;
   }
+
+  .q-collapsed-summary {
+    margin-left: 8px;
+    font-style: italic;
+  }
 }

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -105,6 +105,9 @@
                value="or" #orOption />
         <label (click)="changeCondition(orOption.value)" [ngClass]="getClassNames('switchLabel')">OR</label>
       </div>
+      <span *ngIf="collapsed && config.customCollapsedSummary" [ngClass]="getClassNames('collapsedSummary')">
+        {{ config.customCollapsedSummary(data) }}
+      </span>
     </div>
   </ng-template>
 </ng-template>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -107,7 +107,8 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     inputControl: 'q-input-control',
     inputControlSize: 'q-control-size',
     upIcon: 'q-icon q-up-icon',
-    downIcon: 'q-icon q-down-icon'
+    downIcon: 'q-icon q-down-icon',
+    collapsedSummary: 'q-collapsed-summary'
   };
   public defaultOperatorMap: Record<string, string[]> = {
     string: ['=', '!=', 'contains', 'like'],

--- a/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts
+++ b/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts
@@ -83,6 +83,7 @@ export interface QueryBuilderClassNames {
   inputControlSize?: string;
   upIcon?: string;
   downIcon?: string;
+  collapsedSummary?: string;
 }
 
 export interface QueryBuilderConfig {
@@ -102,6 +103,7 @@ export interface QueryBuilderConfig {
   calculateFieldChangeValue?: (currentField: Field | undefined,
                                nextField: Field | undefined,
                                currentValue: any) => any;
+  customCollapsedSummary?: (ruleset: RuleSet) => string;
 }
 
 export interface SwitchGroupContext {


### PR DESCRIPTION
## Summary
- support `customCollapsedSummary` callback in query builder config
- expose new CSS class and display collapsed summary in the UI
- demo: option to enable collapsed summaries

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869895204b88321aff789e49bd43f55