### PR TITLE
Add popup query builder library

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -46,6 +46,49 @@
         }
       }
     },
+    "popup-ngx-query-builder": {
+      "projectType": "library",
+      "root": "projects/popup-ngx-query-builder",
+      "sourceRoot": "projects/popup-ngx-query-builder/src",
+      "prefix": "popup",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:ng-packagr",
+          "options": {
+            "project": "projects/popup-ngx-query-builder/ng-package.json"
+          },
+          "configurations": {
+            "production": {
+              "tsConfig": "projects/popup-ngx-query-builder/tsconfig.lib.prod.json"
+            },
+            "development": {
+              "tsConfig": "projects/popup-ngx-query-builder/tsconfig.lib.json"
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "tsConfig": "projects/popup-ngx-query-builder/tsconfig.spec.json",
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ]
+          }
+        },
+        "lint": {
+          "builder": "@angular-eslint/builder:lint",
+          "options": {
+            "lintFilePatterns": [
+              "projects/popup-ngx-query-builder/**/*.ts",
+              "projects/popup-ngx-query-builder/**/*.html"
+            ],
+            "eslintConfig": "projects/ngx-query-builder/eslint.config.js"
+          }
+        }
+      }
+    },
     "ngx-query-builder-demo": {
       "projectType": "application",
       "schematics": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "@angular/router": "19.2.14",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "0.15.0"
+    "zone.js": "0.15.0",
+    "primeng": "^17.0.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "19.2.14",

--- a/projects/ngx-query-builder/README.md
+++ b/projects/ngx-query-builder/README.md
@@ -305,3 +305,7 @@ npm link ngx-query-builder
 ```
 
 That's it.
+
+## popup-ngx-query-builder
+
+The `popup-ngx-query-builder` library included in this repository provides a simple component that binds an editable BQL string to an `ngx-query-builder` instance displayed in a PrimeNG dialog. It serves as a starting point for applications that need to edit a boolean query both as text and using the visual query builder.

--- a/projects/popup-ngx-query-builder/README.md
+++ b/projects/popup-ngx-query-builder/README.md
@@ -1,0 +1,13 @@
+# popup-ngx-query-builder
+
+This library provides a small wrapper component that integrates an editable BQL (boolean query language) input field with `@kerwin612/ngx-query-builder`.
+
+The component mimics the UI described in the BirthdayDemo project, showing the query text with a search button that opens the query builder in a PrimeNG dialog. The user can click the text to edit, use the dialog to modify the query tree and keep both representations in sync.
+
+Conversion between the BQL string and the underlying `RuleSet` object is left for the host application. Placeholder methods `bqlToQuery` and `queryToBql` are included for future implementation.
+
+```
+<popup-bql-query-builder [(queryText)]="value" [config]="config"></popup-bql-query-builder>
+```
+
+PrimeNG modules (Dialog, Button, InputText) are used for the pop‑up and styling.

--- a/projects/popup-ngx-query-builder/ng-package.json
+++ b/projects/popup-ngx-query-builder/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/popup-ngx-query-builder",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}

--- a/projects/popup-ngx-query-builder/package.json
+++ b/projects/popup-ngx-query-builder/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "popup-ngx-query-builder",
+  "version": "0.1.0",
+  "peerDependencies": {
+    "@angular/common": "^19.0.0",
+    "@angular/core": "^19.0.0",
+    "primeng": "^17.0.0",
+    "@kerwin612/ngx-query-builder": "^0.6.5"
+  },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "sideEffects": false
+}

--- a/projects/popup-ngx-query-builder/src/lib/bql-popup-query-builder.component.css
+++ b/projects/popup-ngx-query-builder/src/lib/bql-popup-query-builder.component.css
@@ -1,0 +1,16 @@
+.bql-container {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.text-display {
+  flex: 1;
+  padding: 0.25rem;
+  border: 1px solid #ccc;
+  min-height: 1.5rem;
+}
+
+input[pInputText] {
+  flex: 1;
+}

--- a/projects/popup-ngx-query-builder/src/lib/bql-popup-query-builder.component.html
+++ b/projects/popup-ngx-query-builder/src/lib/bql-popup-query-builder.component.html
@@ -1,0 +1,24 @@
+<div class="bql-container">
+  <button type="button" class="search" (click)="openBuilder()">
+    <i class="pi pi-search"></i>
+  </button>
+  <div class="text-display" *ngIf="!editing" (click)="editing = true">
+    <span *ngIf="queryText; else placeholderTmpl">{{ queryText }}</span>
+    <ng-template #placeholderTmpl><em>{{ placeholder }}</em></ng-template>
+  </div>
+  <input *ngIf="editing" pInputText [(ngModel)]="queryText" (blur)="editing = false"/>
+  <button type="button" class="accept" (click)="editing = false">
+    <i class="pi pi-check"></i>
+  </button>
+  <button type="button" class="cancel" (click)="editing = false">
+    <i class="pi pi-times"></i>
+  </button>
+</div>
+<p-dialog [(visible)]="showBuilder" [modal]="true" [style]="{width: '50vw'}">
+  <ng-template pTemplate="header">Query Builder</ng-template>
+  <ngx-query-builder [(ngModel)]="currentQuery" [config]="config"></ngx-query-builder>
+  <ng-template pTemplate="footer">
+    <button pButton type="button" label="Cancel" class="p-button-text" (click)="closeBuilder(false)"></button>
+    <button pButton type="button" label="Ok" (click)="closeBuilder(true)"></button>
+  </ng-template>
+</p-dialog>

--- a/projects/popup-ngx-query-builder/src/lib/bql-popup-query-builder.component.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql-popup-query-builder.component.ts
@@ -1,0 +1,42 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { QueryBuilderConfig, RuleSet } from '@kerwin612/ngx-query-builder';
+
+@Component({
+  selector: 'popup-bql-query-builder',
+  templateUrl: './bql-popup-query-builder.component.html',
+  styleUrls: ['./bql-popup-query-builder.component.css']
+})
+export class BqlPopupQueryBuilderComponent {
+  @Input() queryText = '';
+  @Output() queryTextChange = new EventEmitter<string>();
+  @Input() placeholder = 'Enter query';
+  @Input() config: QueryBuilderConfig = {fields: {}};
+
+  showBuilder = false;
+  editing = false;
+
+  currentQuery: RuleSet = {condition: 'and', rules: []};
+
+  openBuilder(): void {
+    this.currentQuery = this.bqlToQuery(this.queryText);
+    this.showBuilder = true;
+  }
+
+  closeBuilder(apply: boolean): void {
+    if (apply) {
+      this.queryText = this.queryToBql(this.currentQuery);
+      this.queryTextChange.emit(this.queryText);
+    }
+    this.showBuilder = false;
+  }
+
+  private bqlToQuery(bql: string): RuleSet {
+    // TODO: replace with real bql to query conversion
+    return { condition: 'and', rules: [] };
+  }
+
+  private queryToBql(query: RuleSet): string {
+    // TODO: replace with real query to bql conversion
+    return this.queryText;
+  }
+}

--- a/projects/popup-ngx-query-builder/src/lib/popup-ngx-query-builder.module.ts
+++ b/projects/popup-ngx-query-builder/src/lib/popup-ngx-query-builder.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { DialogModule } from 'primeng/dialog';
+import { ButtonModule } from 'primeng/button';
+import { InputTextModule } from 'primeng/inputtext';
+import { NgxQueryBuilderModule } from '@kerwin612/ngx-query-builder';
+import { BqlPopupQueryBuilderComponent } from './bql-popup-query-builder.component';
+
+@NgModule({
+  declarations: [BqlPopupQueryBuilderComponent],
+  imports: [CommonModule, FormsModule, DialogModule, ButtonModule, InputTextModule, NgxQueryBuilderModule],
+  exports: [BqlPopupQueryBuilderComponent]
+})
+export class PopupNgxQueryBuilderModule {}

--- a/projects/popup-ngx-query-builder/src/public-api.ts
+++ b/projects/popup-ngx-query-builder/src/public-api.ts
@@ -1,0 +1,2 @@
+export * from './lib/bql-popup-query-builder.component';
+export * from './lib/popup-ngx-query-builder.module';

--- a/projects/popup-ngx-query-builder/tsconfig.lib.json
+++ b/projects/popup-ngx-query-builder/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/lib-popup",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "**/*.spec.ts"
+  ]
+}

--- a/projects/popup-ngx-query-builder/tsconfig.lib.prod.json
+++ b/projects/popup-ngx-query-builder/tsconfig.lib.prod.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}

--- a/projects/popup-ngx-query-builder/tsconfig.spec.json
+++ b/projects/popup-ngx-query-builder/tsconfig.spec.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- integrate PrimeNG dependency
- add new popup-ngx-query-builder library for editing a boolean query text
- document new component in README

## Testing
- `npx ng lint` *(fails: 403 Forbidden)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a90765d788321904a3395154f64a9