### PR TITLE
Add dynamic GitHub repo categories

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -125,9 +125,15 @@ export class AppComponent implements OnInit {
       },
       repositories: {
         name: 'Repositories',
-        type: 'category'
+        type: 'category',
+        validator: (r, p) => this.repositoriesValidator(r, p),
+        categorySource: (r, p) => this.repositoriesCategorySource(r, p)
       },
-      github: {name: 'Github Id', type: 'string'}  
+      github: {
+        name: 'Github Id',
+        type: 'string',
+        validator: (r, p) => this.githubValidator(r)
+      }
     }
   };
 
@@ -154,6 +160,59 @@ export class AppComponent implements OnInit {
     };
     walk(ruleset);
     return Array.from(names).join(', ');
+  }
+
+  private githubValidator(rule: Rule): any | null {
+    const id = String(rule.value || '').trim();
+    if (!id) {
+      return { field: rule.field, error: 'required' };
+    }
+    try {
+      const req = new XMLHttpRequest();
+      req.open('GET', `https://api.github.com/users/${encodeURIComponent(id)}`, false);
+      req.send();
+      if (req.status === 404) {
+        return { field: rule.field, error: 'notfound' };
+      }
+    } catch {
+      return { field: rule.field, error: 'notfound' };
+    }
+    return null;
+  }
+
+  private repositoriesValidator(rule: Rule, parent: RuleSet): any | null {
+    if (parent.condition !== 'and') {
+      return { field: rule.field, error: 'parent-not-and' };
+    }
+    const githubRule = parent.rules.find(r => (r as Rule).field === 'github') as Rule | undefined;
+    if (!githubRule) {
+      return { field: rule.field, error: 'missing-github' };
+    }
+    const err = this.githubValidator(githubRule);
+    if (err) {
+      return { field: rule.field, error: 'invalid-github' };
+    }
+    return null;
+  }
+
+  private repositoriesCategorySource(rule: Rule, parent: RuleSet): string[] | null {
+    const githubRule = parent.rules.find(r => (r as Rule).field === 'github') as Rule | undefined;
+    const id = githubRule && String(githubRule.value || '').trim();
+    if (!id) {
+      return null;
+    }
+    try {
+      const req = new XMLHttpRequest();
+      req.open('GET', `https://api.github.com/users/${encodeURIComponent(id)}/repos`, false);
+      req.send();
+      if (req.status === 200) {
+        const data = JSON.parse(req.responseText);
+        return Array.isArray(data) ? data.map((d: any) => d.name) : null;
+      }
+    } catch {
+      // ignore errors
+    }
+    return null;
   }
 
   updateCollapsedSummary() {

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -242,7 +242,7 @@
 <!--_inputTpl-->
 <ng-template #_inputTpl let-rule>
   <ng-container *ngIf="findTemplateForRule(rule) as template; else defaultInput">
-    <ng-container *ngTemplateOutlet="template; context: getInputContext(rule)"></ng-container>
+    <ng-container *ngTemplateOutlet="template; context: getInputContext(rule, data)"></ng-container>
   </ng-container>
   <ng-template #defaultInput>
     <div [ngClass]="getClassNames('inputControlSize')" [ngSwitch]="getInputType(rule.field, rule.operator || '')">
@@ -256,14 +256,14 @@
              [disabled]="disabled" *ngSwitchCase="'time'" type="time">
       <select [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"
               [disabled]="disabled" *ngSwitchCase="'category'">
-        <option *ngFor="let opt of getOptions(rule.field)" [ngValue]="opt.value">
+        <option *ngFor="let opt of getOptions(rule.field, rule, data)" [ngValue]="opt.value">
           {{opt.name}}
         </option>
       </select>
       <ng-container *ngSwitchCase="'multiselect'">
         <select [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"
                 [disabled]="disabled" multiple>
-          <option *ngFor="let opt of getOptions(rule.field)" [ngValue]="opt.value">
+          <option *ngFor="let opt of getOptions(rule.field, rule, data)" [ngValue]="opt.value">
             {{opt.name}}
           </option>
         </select>


### PR DESCRIPTION
## Summary
- enable dynamic category options using `categorySource`
- update demo to validate GitHub ids and repositories
- fetch repository names from GitHub for repo category

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module '@angular/core')*

------
https://chatgpt.com/codex/tasks/task_e_686d78cfe6a88321bfc720ec01bcd949