### PR TITLE
Fix missing ruleset delete buttons

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -143,7 +143,7 @@
               (click)="convertRulesetToRule(data, parentValue)" [ngClass]="getClassNames('button')" [disabled]="disabled">
         Convert to Rule
       </button>
-      <ng-container *ngIf="!!parentValue && allowRuleset">
+      <ng-container *ngIf="!!parentValue">
         <ng-container *ngTemplateOutlet="_rulesetRemoveButtonTpl"></ng-container>
       </ng-container>
     </div>


### PR DESCRIPTION
## Summary
- show remove button for rulesets even when `allowRuleset` is false

## Testing
- `npm test --silent -- --no-watch --no-progress` *(fails: ng not found)*
- `npm run lint --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9d9e8e88832192d11eecaeb5bafa