### PR TITLE
Add label customization and expression option

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -1,6 +1,6 @@
 <main class="main">
   <div class="content">
-    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [allowConvertToRuleset]='allowConvertToRuleset' [allowRuleUpDown]='allowRuleUpDown' [persistValueOnFieldChange]='persistValueOnFieldChange'>
+    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [allowConvertToRuleset]='allowConvertToRuleset' [allowRuleUpDown]='allowRuleUpDown' [persistValueOnFieldChange]='persistValueOnFieldChange' [ruleName]='ruleName' [rulesetName]='rulesetName'>
       <ng-container *queryInput="let rule; type: 'textarea'; let getDisabledState=getDisabledState; let onChange=onChange">
       <textarea class="text-input text-area" [(ngModel)]="rule.value" (ngModelChange)="onChange()" [disabled]=getDisabledState()
                 placeholder="Custom Textarea"></textarea>
@@ -37,6 +37,9 @@
         </div>
         <div>
           <label><input type="checkbox" [(ngModel)]='allowRuleUpDown'>Allow Rule Up/Down</label>
+        </div>
+        <div>
+          <label><input type="checkbox" [(ngModel)]='useExpressionNames' (change)='toggleExpressionNames()'>Expression</label>
         </div>
         <div>
           <label><input type="checkbox" (change)=changeDisabled($event)>Disabled</label>

--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -146,6 +146,9 @@ export class AppComponent implements OnInit {
   public allowRuleUpDown: boolean = false;
   public persistValueOnFieldChange: boolean = false;
   public useCollapsedSummary: boolean = false;
+  public ruleName: string = 'Rule';
+  public rulesetName: string = 'Ruleset';
+  public useExpressionNames: boolean = false;
 
   public collapsedSummary(ruleset: RuleSet): string {
     const names = new Set<string>();
@@ -453,5 +456,15 @@ export class AppComponent implements OnInit {
   changeLevelLimit(event: Event) {
     this.currentConfig = {...this.currentConfig, levelLimit: parseInt((<HTMLInputElement>event.target).value, 10)} as QueryBuilderConfig;
     this.updateCollapsedSummary();
+  }
+
+  toggleExpressionNames() {
+    if (this.useExpressionNames) {
+      this.ruleName = 'Expression';
+      this.rulesetName = 'Query';
+    } else {
+      this.ruleName = 'Rule';
+      this.rulesetName = 'Ruleset';
+    }
   }
 }

--- a/projects/ngx-query-builder/README.md
+++ b/projects/ngx-query-builder/README.md
@@ -128,6 +128,8 @@ config: QueryBuilderConfig = {
 |`allowCollapse`| `boolean` |Optional| `true`                          | Enables collapsible rule sets if `true`. |
 |`allowConvertToRuleset`| `boolean` |Optional| `false` | Displays the `Convert to Ruleset` button if `true`. Rulesets with a single entry also show a `Convert to Rule` button (except the root ruleset). |
 |`allowRuleUpDown`| `boolean` |Optional| `false` | Displays up and down arrows on rules and nested rulesets for reordering. |
+|`ruleName`| `string` |Optional| `'Rule'` | Label used in default buttons for rules. |
+|`rulesetName`| `string` |Optional| `'Ruleset'` | Label used in default buttons for rulesets. |
 |`allowNot`| `boolean` |Optional| `false`                          | Adds a `NOT` button and sets a `not` attribute on the ruleset JSON. |
 |`classNames`| [`QueryBuilderClassNames`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L48)                                                                      |Optional|                                  | CSS class names for different child elements in `query-builder` component. |
 |`config`| [`QueryBuilderConfig`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L85)                                                                          |Required|                                  | Configuration object for the main component. |

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -40,8 +40,8 @@
                             [disabled]="disabled || i === data.rules.length - 1">
                       <i [ngClass]="getClassNames('downIcon')"></i>
                     </button>
-                    <button *ngIf="allowConvertToRuleset" type="button" (click)="convertToRuleset(rule, data)" [ngClass]="getClassNames('button')" [disabled]="disabled">
-                      Convert to Ruleset
+                    <button *ngIf="allowConvertToRuleset" type="button" (click)="convertToRuleset(rule, data)" [title]="'Convert to a ' + rulesetName" [ngClass]="getClassNames('button')" [disabled]="disabled">
+                      = {{rulesetName}}
                     </button>
                     <ng-template [ngTemplateOutlet]="_ruleRemoveButtonTpl" [ngTemplateOutletContext]="{ $implicit: rule }"/>
                   </div>
@@ -140,8 +140,8 @@
         </button>
       </ng-container>
       <button *ngIf="allowConvertToRuleset && parentValue && data.rules.length === 1" type="button"
-              (click)="convertRulesetToRule(data, parentValue)" [ngClass]="getClassNames('button')" [disabled]="disabled">
-        Convert to Rule
+              (click)="convertRulesetToRule(data, parentValue)" [title]="'Convert to a ' + ruleName" [ngClass]="getClassNames('button')" [disabled]="disabled">
+        = {{ruleName}}
       </button>
       <ng-container *ngIf="!!parentValue">
         <ng-container *ngTemplateOutlet="_rulesetRemoveButtonTpl"></ng-container>
@@ -158,7 +158,7 @@
 
   <ng-template #defaultRulesetAddRuleButton>
     <button type="button" (click)="addRule()" [ngClass]="getClassNames('button')" [disabled]=disabled>
-      <i [ngClass]="getClassNames('addIcon')"></i> Rule
+      <i [ngClass]="getClassNames('addIcon')"></i> {{ruleName}}
     </button>
   </ng-template>
 </ng-template>
@@ -171,7 +171,7 @@
 
   <ng-template #defaultRulesetAddRulesetButton>
     <button type="button" (click)="addRuleSet()" [ngClass]="getClassNames('button')" *ngIf="allowRuleset" [disabled]=disabled>
-      <i [ngClass]="getClassNames('addIcon')"></i> Ruleset
+      <i [ngClass]="getClassNames('addIcon')"></i> {{rulesetName}}
     </button>
   </ng-template>
 </ng-template>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -132,6 +132,8 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   @Input() allowCollapse = true;
   @Input() allowRuleUpDown = false;
   @Input() emptyMessage = 'A ruleset cannot be empty. Please add a rule or remove it all together.';
+  @Input() ruleName = 'Rule';
+  @Input() rulesetName = 'Ruleset';
   @Input() classNames!: QueryBuilderClassNames;
   @Input() operatorMap!: Record<string, string[]>;
   @Input() parentValue!: RuleSet;


### PR DESCRIPTION
## Summary
- add `ruleName` and `rulesetName` inputs
- display substitute names in add/convert buttons
- update demo with Expression toggle
- document new inputs

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da2af62808321bb5bdad6a5c39d56