### PR TITLE
Fix expression naming and icon styling

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -27,7 +27,8 @@
 
   .q-equal-icon {
     fill: currentColor;
-    vertical-align: text-bottom;
+    vertical-align: -1px;
+    color: rgb(52 47 167)
   }
 
   .q-up-icon {

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -26,7 +26,7 @@
   }
 
   .q-equal-icon {
-    fill: #555;
+    fill: currentColor;
     vertical-align: text-bottom;
   }
 

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -63,7 +63,7 @@
                                  [parentEmptyWarningTemplate]="parentEmptyWarningTemplate || emptyWarningTemplate" [parentArrowIconTemplate]="parentArrowIconTemplate || arrowIconTemplate"
                                  [parentValue]="data" [classNames]="classNames" [config]="config" [allowRuleset]="allowRuleset"
                                  [allowCollapse]="allowCollapse" [allowNot]="allowNot" [allowConvertToRuleset]="allowConvertToRuleset"
-                                 [allowRuleUpDown]="allowRuleUpDown"
+                                 [allowRuleUpDown]="allowRuleUpDown" [ruleName]="ruleName" [rulesetName]="rulesetName"
                                  [emptyMessage]="emptyMessage" [operatorMap]="operatorMap">
               </ngx-query-builder>
             </li>


### PR DESCRIPTION
## Summary
- propagate `ruleName` and `rulesetName` down to nested query builders
- inherit colour for equal icon so it matches the add button

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dab69fc3c8321bf7e93b1ca99662f