### PR TITLE
Add hideButtons option

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -1,6 +1,6 @@
 <main class="main">
   <div class="content">
-    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [allowConvertToRuleset]='allowConvertToRuleset' [allowRuleUpDown]='allowRuleUpDown' [persistValueOnFieldChange]='persistValueOnFieldChange' [ruleName]='ruleName' [rulesetName]='rulesetName'>
+    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [allowConvertToRuleset]='allowConvertToRuleset' [allowRuleUpDown]='allowRuleUpDown' [persistValueOnFieldChange]='persistValueOnFieldChange' [ruleName]='ruleName' [rulesetName]='rulesetName' [hideButtons]='hideButtons'>
       <ng-container *queryInput="let rule; type: 'textarea'; let getDisabledState=getDisabledState; let onChange=onChange">
       <textarea class="text-input text-area" [(ngModel)]="rule.value" (ngModelChange)="onChange()" [disabled]=getDisabledState()
                 placeholder="Custom Textarea"></textarea>
@@ -37,6 +37,9 @@
         </div>
         <div>
           <label><input type="checkbox" [(ngModel)]='allowRuleUpDown'>Allow Rule Up/Down</label>
+        </div>
+        <div>
+          <label><input type="checkbox" [(ngModel)]='hideButtons'>Hide Buttons</label>
         </div>
         <div>
           <label><input type="checkbox" [(ngModel)]='useExpressionNames' (change)='toggleExpressionNames()'>Expression</label>

--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -144,6 +144,7 @@ export class AppComponent implements OnInit {
   public allowNot: boolean = false;
   public allowConvertToRuleset: boolean = false;
   public allowRuleUpDown: boolean = false;
+  public hideButtons: boolean = false;
   public persistValueOnFieldChange: boolean = false;
   public useCollapsedSummary: boolean = false;
   public ruleName: string = 'Rule';

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -187,6 +187,29 @@
     }
   }
 
+  .q-button-wrapper.q-hide-buttons .q-buttons {
+    display: none;
+  }
+
+  .q-button-wrapper .q-buttons {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+  }
+
+  .q-button-wrapper.q-hide-buttons:hover .q-buttons {
+    display: flex;
+  }
+
+  .q-button-wrapper.q-hide-buttons .q-ellipsis {
+    cursor: pointer;
+    padding: 0 4px;
+  }
+
+  .q-button-wrapper.q-hide-buttons:hover .q-ellipsis {
+    display: none;
+  }
+
   .q-invalid-ruleset {
     border: 1px solid rgba(179, 65, 93, 0.5) !important;
     background: rgba(179, 65, 93, 0.1) !important;

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -29,7 +29,9 @@
                     <ng-template [ngTemplateOutlet]="_inputTpl" [ngTemplateOutletContext]="{ $implicit: rule }"/>
                   </div>
 
-                  <div [ngClass]="getClassNames('ruleActions')">
+                  <div [ngClass]="getClassNames('ruleActions')" class="q-button-wrapper" [class.q-hide-buttons]="hideButtons">
+                    <span *ngIf="hideButtons" class="q-ellipsis">&hellip;</span>
+                    <div class="q-buttons">
                     <button *ngIf="allowRuleUpDown && data.rules.length > 1" type="button" (click)="moveRuleUp(rule, data)"
                             [ngClass]="getClassNames('button')"
                             [disabled]="disabled || i === 0">
@@ -47,6 +49,7 @@
                       {{rulesetName}}
                     </button>
                     <ng-template [ngTemplateOutlet]="_ruleRemoveButtonTpl" [ngTemplateOutletContext]="{ $implicit: rule }"/>
+                    </div>
                   </div>
                 </div>
               </ng-container>
@@ -64,6 +67,7 @@
                                  [parentValue]="data" [classNames]="classNames" [config]="config" [allowRuleset]="allowRuleset"
                                  [allowCollapse]="allowCollapse" [allowNot]="allowNot" [allowConvertToRuleset]="allowConvertToRuleset"
                                  [allowRuleUpDown]="allowRuleUpDown" [ruleName]="ruleName" [rulesetName]="rulesetName"
+                                 [hideButtons]="hideButtons"
                                  [emptyMessage]="emptyMessage" [operatorMap]="operatorMap">
               </ngx-query-builder>
             </li>
@@ -94,17 +98,17 @@
   <ng-template #defaultSwitchGroup>
     <div [ngClass]="getClassNames('switchGroup', 'transition')" *ngIf="data"
          (mouseenter)="hoveringSwitchGroup = true" (mouseleave)="hoveringSwitchGroup = false">
-      <div [ngClass]="getClassNames('switchControl')" *ngIf="allowNot && (hoveringSwitchGroup || data.not)">
+      <div [ngClass]="getClassNames('switchControl')" *ngIf="allowNot && (!hideButtons || hoveringSwitchGroup || data.not)">
         <input type="checkbox" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.not"
                (ngModelChange)="changeNot($event)" [disabled]="disabled" />
         <label (click)="changeNot(!data.not)" [ngClass]="getClassNames('switchLabel')">NOT</label>
       </div>
-      <div [ngClass]="getClassNames('switchControl')" *ngIf="hoveringSwitchGroup || data.condition === 'and'">
+      <div [ngClass]="getClassNames('switchControl')" *ngIf="!hideButtons || hoveringSwitchGroup || data.condition === 'and'">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="and" #andOption />
         <label (click)="changeCondition(andOption.value)" [ngClass]="getClassNames('switchLabel')">AND</label>
       </div>
-      <div [ngClass]="getClassNames('switchControl')" *ngIf="hoveringSwitchGroup || data.condition === 'or'">
+      <div [ngClass]="getClassNames('switchControl')" *ngIf="!hideButtons || hoveringSwitchGroup || data.condition === 'or'">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="or" #orOption />
         <label (click)="changeCondition(orOption.value)" [ngClass]="getClassNames('switchLabel')">OR</label>
@@ -125,7 +129,9 @@
   </ng-container>
 
   <ng-template #defaultButtonGroup>
-    <div [ngClass]="getClassNames('buttonGroup', 'rightAlign')">
+    <div [ngClass]="getClassNames('buttonGroup', 'rightAlign')" class="q-button-wrapper" [class.q-hide-buttons]="hideButtons">
+      <span *ngIf="hideButtons" class="q-ellipsis">&hellip;</span>
+      <div class="q-buttons">
       <ng-container *ngIf="!config.rulesLimit || data.rules.length < config.rulesLimit">
         <ng-container *ngTemplateOutlet="_rulesetAddRuleButtonTpl"></ng-container>
         <ng-container *ngIf="!config.levelLimit || level + 1 < config.levelLimit">
@@ -149,9 +155,10 @@
         </svg>
         {{ruleName}}
       </button>
-      <ng-container *ngIf="!!parentValue">
-        <ng-container *ngTemplateOutlet="_rulesetRemoveButtonTpl"></ng-container>
-      </ng-container>
+        <ng-container *ngIf="!!parentValue">
+          <ng-container *ngTemplateOutlet="_rulesetRemoveButtonTpl"></ng-container>
+        </ng-container>
+      </div>
     </div>
   </ng-template>
 </ng-template>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -132,6 +132,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   @Input() allowConvertToRuleset = false;
   @Input() allowCollapse = true;
   @Input() allowRuleUpDown = false;
+  @Input() hideButtons = false;
   @Input() emptyMessage = 'A ruleset cannot be empty. Please add a rule or remove it all together.';
   @Input() ruleName = 'Rule';
   @Input() rulesetName = 'Ruleset';


### PR DESCRIPTION
## Summary
- add `hideButtons` boolean input for QueryBuilder
- pass `hideButtons` through nested builders
- hide switch controls unless hovered when `hideButtons` enabled
- display ellipsis for action buttons when `hideButtons` enabled
- expose `hideButtons` option in demo with a checkbox

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686daff8a3d88321ac7b74c7d7af7169