### PR TITLE
Adjust switch group button visibility

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -98,20 +98,26 @@
   <ng-template #defaultSwitchGroup>
     <div [ngClass]="getClassNames('switchGroup', 'transition')" *ngIf="data"
          (mouseenter)="hoveringSwitchGroup = true" (mouseleave)="hoveringSwitchGroup = false">
-      <div [ngClass]="getClassNames('switchControl')" *ngIf="allowNot && (!hideButtons || hoveringSwitchGroup || data.not)">
+      <div [ngClass]="getClassNames('switchControl')" *ngIf="allowNot && (hoveringSwitchGroup || data.not || data.rules.length === 1)">
         <input type="checkbox" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.not"
                (ngModelChange)="changeNot($event)" [disabled]="disabled" />
-        <label (click)="changeNot(!data.not)" [ngClass]="getClassNames('switchLabel')">NOT</label>
+        <label (click)="changeNot(!data.not)" [ngClass]="getClassNames('switchLabel')">
+          <ng-container *ngIf="data.rules.length !== 1">NOT</ng-container>
+        </label>
       </div>
-      <div [ngClass]="getClassNames('switchControl')" *ngIf="!hideButtons || hoveringSwitchGroup || data.condition === 'and'">
+      <div [ngClass]="getClassNames('switchControl')" *ngIf="hoveringSwitchGroup || data.condition === 'and' || data.rules.length === 1">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="and" #andOption />
-        <label (click)="changeCondition(andOption.value)" [ngClass]="getClassNames('switchLabel')">AND</label>
+        <label (click)="changeCondition(andOption.value)" [ngClass]="getClassNames('switchLabel')">
+          <ng-container *ngIf="data.rules.length !== 1">AND</ng-container>
+        </label>
       </div>
-      <div [ngClass]="getClassNames('switchControl')" *ngIf="!hideButtons || hoveringSwitchGroup || data.condition === 'or'">
+      <div [ngClass]="getClassNames('switchControl')" *ngIf="hoveringSwitchGroup || data.condition === 'or' || data.rules.length === 1">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="or" #orOption />
-        <label (click)="changeCondition(orOption.value)" [ngClass]="getClassNames('switchLabel')">OR</label>
+        <label (click)="changeCondition(orOption.value)" [ngClass]="getClassNames('switchLabel')">
+          <ng-container *ngIf="data.rules.length !== 1">OR</ng-container>
+        </label>
       </div>
       <span *ngIf="collapsed && config.customCollapsedSummary" [ngClass]="getClassNames('collapsedSummary')">
         {{ config.customCollapsedSummary(data) }}


### PR DESCRIPTION
## Summary
- hide the switch group unless hovered or active
- show a blank NOT/AND/OR switch when there is only one rule

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e590f0390832198cb717b8d0f5e52