### PR TITLE
Add default attribute option and improve single ruleset UI

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -1,6 +1,6 @@
 <main class="main">
   <div class="content">
-    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [allowConvertToRuleset]='allowConvertToRuleset' [allowRuleUpDown]='allowRuleUpDown' [persistValueOnFieldChange]='persistValueOnFieldChange' [ruleName]='ruleName' [rulesetName]='rulesetName' [hideButtons]='hideButtons'>
+    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [allowConvertToRuleset]='allowConvertToRuleset' [allowRuleUpDown]='allowRuleUpDown' [persistValueOnFieldChange]='persistValueOnFieldChange' [defaultAttribute]='defaultAttribute' [ruleName]='ruleName' [rulesetName]='rulesetName' [hideButtons]='hideButtons'>
       <ng-container *queryInput="let rule; type: 'textarea'; let getDisabledState=getDisabledState; let onChange=onChange">
       <textarea class="text-input text-area" [(ngModel)]="rule.value" (ngModelChange)="onChange()" [disabled]=getDisabledState()
                 placeholder="Custom Textarea"></textarea>

--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -146,6 +146,7 @@ export class AppComponent implements OnInit {
   public allowRuleUpDown: boolean = false;
   public hideButtons: boolean = false;
   public persistValueOnFieldChange: boolean = false;
+  public defaultAttribute: string = 'name';
   public useCollapsedSummary: boolean = false;
   public ruleName: string = 'Rule';
   public rulesetName: string = 'Ruleset';

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -113,6 +113,9 @@
                value="or" #orOption />
         <label (click)="changeCondition(orOption.value)" [ngClass]="getClassNames('switchLabel')">OR</label>
       </div>
+      <div [ngClass]="getClassNames('switchControl')" *ngIf="data.rules.length === 1 && (!hideButtons || hoveringSwitchGroup)">
+        <label [ngClass]="getClassNames('switchLabel')">&nbsp;</label>
+      </div>
       <span *ngIf="collapsed && config.customCollapsedSummary" [ngClass]="getClassNames('collapsedSummary')">
         {{ config.customCollapsedSummary(data) }}
       </span>


### PR DESCRIPTION
## Summary
- show a placeholder connector when a ruleset contains a single rule
- introduce `defaultAttribute` input for query builder
- automatically add a rule whenever a new ruleset is created
- demo uses `defaultAttribute="name"`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5f02911883219c4d8967fc8a3246