### PR TITLE
Add automatic rule for new rulesets

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -137,6 +137,10 @@
     padding: 0 8px;
   }
 
+  .q-switch-label-empty {
+    visibility: hidden;
+  }
+
   .q-switch-radio {
     position: absolute;
     clip: rect(0, 0, 0, 0);

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -109,14 +109,16 @@
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="and" #andOption />
         <label (click)="changeCondition(andOption.value)" [ngClass]="getClassNames('switchLabel')">
-          <ng-container *ngIf="data.rules.length !== 1">AND</ng-container>
+          <ng-container *ngIf="data.rules.length !== 1; else blankAnd">AND</ng-container>
+          <ng-template #blankAnd><span class="q-switch-label-empty">AND</span></ng-template>
         </label>
       </div>
       <div [ngClass]="getClassNames('switchControl')" *ngIf="hoveringSwitchGroup || data.condition === 'or' || data.rules.length === 1">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="or" #orOption />
         <label (click)="changeCondition(orOption.value)" [ngClass]="getClassNames('switchLabel')">
-          <ng-container *ngIf="data.rules.length !== 1">OR</ng-container>
+          <ng-container *ngIf="data.rules.length !== 1; else blankOr">OR</ng-container>
+          <ng-template #blankOr><span class="q-switch-label-empty">OR</span></ng-template>
         </label>
       </div>
       <span *ngIf="collapsed && config.customCollapsedSummary" [ngClass]="getClassNames('collapsedSummary')">

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -562,18 +562,25 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     }
 
     parent = parent || this.data;
+    let newRuleset: RuleSet | undefined;
     if (this.config.addRuleSet) {
       this.config.addRuleSet(parent);
+      const last = parent.rules[parent.rules.length - 1];
+      if (this.isRuleset(last)) {
+        newRuleset = last as RuleSet;
+      }
     } else {
       const rs: RuleSet = { condition: 'and', rules: [] };
       if (this.allowNot) {
         rs.not = false;
       }
       parent.rules = parent.rules.concat([rs]);
+      newRuleset = rs;
     }
 
-    this.handleTouched();
-    this.handleDataChange();
+    if (newRuleset) {
+      this.addRule(newRuleset);
+    }
   }
 
   removeRuleSet(ruleset?: RuleSet, parent?: RuleSet): void {


### PR DESCRIPTION
## Summary
- auto-add a rule when creating a ruleset
- show blank OR/AND placeholders sized like the original labels

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e643aa620832196e499812d70360e