### PR TITLE
Fix single rule switch layout

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -139,6 +139,8 @@
 
   .q-switch-label-empty {
     visibility: hidden;
+    display: inline-block;
+    width: 12px;
   }
 
   .q-switch-radio {

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -105,7 +105,7 @@
           <ng-container *ngIf="data.rules.length !== 1">NOT</ng-container>
         </label>
       </div>
-      <div [ngClass]="getClassNames('switchControl')" *ngIf="hoveringSwitchGroup || data.condition === 'and' || data.rules.length === 1">
+      <div [ngClass]="getClassNames('switchControl')" *ngIf="hoveringSwitchGroup || data.condition === 'and'">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="and" #andOption />
         <label (click)="changeCondition(andOption.value)" [ngClass]="getClassNames('switchLabel')">
@@ -113,7 +113,7 @@
           <ng-template #blankAnd><span class="q-switch-label-empty">AND</span></ng-template>
         </label>
       </div>
-      <div [ngClass]="getClassNames('switchControl')" *ngIf="hoveringSwitchGroup || data.condition === 'or' || data.rules.length === 1">
+      <div [ngClass]="getClassNames('switchControl')" *ngIf="hoveringSwitchGroup || data.condition === 'or'">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="or" #orOption />
         <label (click)="changeCondition(orOption.value)" [ngClass]="getClassNames('switchLabel')">


### PR DESCRIPTION
## Summary
- show only the active AND/OR toggle when there's one rule
- size blank toggle label square

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e67d1a19c832194b74dfc1f724c0f