### PR TITLE
Fix allowNot layout line issue

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -102,7 +102,8 @@
         <input type="checkbox" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.not"
                (ngModelChange)="changeNot($event)" [disabled]="disabled" />
         <label (click)="changeNot(!data.not)" [ngClass]="getClassNames('switchLabel')">
-          <ng-container *ngIf="data.rules.length !== 1">NOT</ng-container>
+          <ng-container *ngIf="data.rules.length !== 1; else blankNot">NOT</ng-container>
+          <ng-template #blankNot><span class="q-switch-label-empty">NOT</span></ng-template>
         </label>
       </div>
       <div [ngClass]="getClassNames('switchControl')" *ngIf="hoveringSwitchGroup || data.condition === 'and'">


### PR DESCRIPTION
## Summary
- ensure NOT switch label reserves width when blank

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6c765a9c8321a2c21e58b2ca7e8d