### PR TITLE
Fix switch controls when allowNot is enabled

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -98,15 +98,15 @@
   <ng-template #defaultSwitchGroup>
     <div [ngClass]="getClassNames('switchGroup', 'transition')" *ngIf="data"
          (mouseenter)="hoveringSwitchGroup = true" (mouseleave)="hoveringSwitchGroup = false">
-      <div [ngClass]="getClassNames('switchControl')" *ngIf="allowNot && (hoveringSwitchGroup || data.not || data.rules.length === 1)">
+      <div [ngClass]="getClassNames('switchControl')" *ngIf="allowNot && (data.not || (hoveringSwitchGroup && data.rules.length !== 1))">
         <input type="checkbox" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.not"
                (ngModelChange)="changeNot($event)" [disabled]="disabled" />
         <label (click)="changeNot(!data.not)" [ngClass]="getClassNames('switchLabel')">
-          <ng-container *ngIf="data.rules.length !== 1; else blankNot">NOT</ng-container>
-          <ng-template #blankNot><span class="q-switch-label-empty">NOT</span></ng-template>
+          NOT
         </label>
       </div>
-      <div [ngClass]="getClassNames('switchControl')" *ngIf="hoveringSwitchGroup || data.condition === 'and'">
+      <div [ngClass]="getClassNames('switchControl')"
+           *ngIf="data.condition === 'and' || (hoveringSwitchGroup && data.rules.length !== 1)">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="and" #andOption />
         <label (click)="changeCondition(andOption.value)" [ngClass]="getClassNames('switchLabel')">
@@ -114,7 +114,8 @@
           <ng-template #blankAnd><span class="q-switch-label-empty">AND</span></ng-template>
         </label>
       </div>
-      <div [ngClass]="getClassNames('switchControl')" *ngIf="hoveringSwitchGroup || data.condition === 'or'">
+      <div [ngClass]="getClassNames('switchControl')"
+           *ngIf="data.condition === 'or' || (hoveringSwitchGroup && data.rules.length !== 1)">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="or" #orOption />
         <label (click)="changeCondition(orOption.value)" [ngClass]="getClassNames('switchLabel')">


### PR DESCRIPTION
## Summary
- ensure NOT toggle doesn't appear for single-rule rulesets
- avoid showing extra condition toggles on hover when there is only one rule

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e749735708321930e5a01209647bb