### PR TITLE
Add rule and ruleset validation indicators

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -296,4 +296,13 @@
     font-size: 0.85em;
     align-self: center;
   }
+
+  .q-invalid-message {
+    font-size: 0.75em;
+    font-style: italic;
+    font-weight: 300;
+    color: #666;
+    align-self: center;
+    margin-right: 8px;
+  }
 }

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="{ruleset: isRuleset(data), invalid: !config.allowEmptyRulesets && isEmptyRuleset(data)} as local">
+<ng-container *ngIf="{ruleset: isRuleset(data), invalidEmpty: !config.allowEmptyRulesets && isEmptyRuleset(data), invalid: isRulesetInvalid(data)} as local">
   <div [ngClass]="getQueryRulesetClassName(local)">
     <div [ngClass]="getClassNames('switchRow')">
       <a *ngIf="allowCollapse" (click)="toggleCollapse()" [ngClass]="getClassNames('arrowIconButton', collapsed ? 'collapsed' : null)">
@@ -31,6 +31,7 @@
 
                   <div [ngClass]="getClassNames('ruleActions')" class="q-button-wrapper" [class.q-hide-buttons]="hideButtons">
                     <span *ngIf="hideButtons" class="q-ellipsis">&hellip;</span>
+                    <span class="q-invalid-message" *ngIf="isRuleInvalid(rule, data)">Invalid {{ruleName}}</span>
                     <div class="q-buttons">
                     <button *ngIf="allowRuleUpDown && data.rules.length > 1" type="button" (click)="moveRuleUp(rule, data)"
                             [ngClass]="getClassNames('button')"
@@ -141,6 +142,7 @@
   <ng-template #defaultButtonGroup>
     <div [ngClass]="getClassNames('buttonGroup', 'rightAlign')" class="q-button-wrapper" [class.q-hide-buttons]="hideButtons">
       <span *ngIf="hideButtons" class="q-ellipsis">&hellip;</span>
+      <span class="q-invalid-message" *ngIf="isRulesetInvalid(data)">Invalid {{rulesetName}}</span>
       <div class="q-buttons">
       <ng-container *ngIf="!config.rulesLimit || data.rules.length < config.rulesLimit">
         <ng-container *ngTemplateOutlet="_rulesetAddRuleButtonTpl"></ng-container>
@@ -318,13 +320,13 @@
 <!--_emptyWarningTpl-->
 <ng-template #_emptyWarningTpl let-local>
   <ng-container *ngIf="getEmptyWarningTemplate() as template; else defaultEmptyWarning">
-    <ng-container *ngIf="local.invalid">
+    <ng-container *ngIf="local.invalidEmpty">
       <ng-container *ngTemplateOutlet="template; context: getEmptyWarningContext()"></ng-container>
     </ng-container>
   </ng-container>
 
   <ng-template #defaultEmptyWarning>
-    <p [ngClass]="getClassNames('emptyWarning')" *ngIf="local.invalid">
+    <p [ngClass]="getClassNames('emptyWarning')" *ngIf="local.invalidEmpty">
       {{emptyMessage}}
     </p>
   </ng-template>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -958,6 +958,25 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     return rule.rules && rule.rules.length === 0;
   }
 
+  isRuleInvalid(rule: Rule, parent: RuleSet = this.data): boolean {
+    const field = this.config.fields[rule.field];
+    if (field && field.validator) {
+      return field.validator(rule, parent) != null;
+    } else if (field && field.type === 'textarea') {
+      const requiresValue = rule.operator !== 'is null' && rule.operator !== 'is not null';
+      return requiresValue && (typeof rule.value !== 'string' || rule.value.trim() === '');
+    }
+    return false;
+  }
+
+  isRulesetInvalid(ruleset: RuleSet): boolean {
+    if (!ruleset || !ruleset.rules) { return false; }
+    if (!this.config.allowEmptyRulesets && this.isEmptyRuleset(ruleset)) {
+      return true;
+    }
+    return ruleset.rules.some((r) => this.isRuleset(r) ? this.isRulesetInvalid(r) : this.isRuleInvalid(r as Rule, ruleset));
+  }
+
   private calculateFieldChangeValue(
     currentField: Field | undefined,
     nextField: Field | undefined,


### PR DESCRIPTION
## Summary
- mark rule and ruleset invalidity in the UI
- display small invalid messages near rule and ruleset buttons
- add helper methods for checking rule and ruleset validity
- style invalid message text

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7a93a4fc83219f4bfe1e9ed6d3b8