### PR TITLE
Fix date initialization and validation

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -45,7 +45,7 @@ export class AppComponent implements OnInit {
     condition: 'and',
     rules: [
       {field: 'age', operator: '<='},
-      {field: 'birthday', operator: '=', value: new Date()},
+      {field: 'birthday', operator: '=', value: (() => { const d = new Date(); d.setHours(0,0,0,0); return d; })()},
       {
         condition: 'or',
         rules: [
@@ -78,7 +78,7 @@ export class AppComponent implements OnInit {
       notes: {name: 'Notes', type: 'textarea', operators: ['=', '!='], entity: 'nonphysical'},
       educated: {name: 'College Degree?', type: 'boolean', entity: 'nonphysical'},
       birthday: {name: 'Birthday', type: 'date', operators: ['=', '<=', '>'],
-        defaultValue: (() => new Date()), entity: 'nonphysical'
+        defaultValue: (() => { const d = new Date(); d.setHours(0,0,0,0); return d; }), entity: 'nonphysical'
       },
       school: {name: 'School', type: 'string', nullable: true, entity: 'nonphysical'},
       occupation: {
@@ -110,7 +110,7 @@ export class AppComponent implements OnInit {
       notes: {name: 'Notes', type: 'textarea', operators: ['=', '!=']},
       educated: {name: 'College Degree?', type: 'boolean'},
       birthday: {name: 'Birthday', type: 'date', operators: ['=', '<=', '>'],
-        defaultValue: (() => new Date())
+        defaultValue: (() => { const d = new Date(); d.setHours(0,0,0,0); return d; })
       },
       school: {name: 'School', type: 'string', nullable: true},
       occupation: {

--- a/projects/ngx-query-builder/README.md
+++ b/projects/ngx-query-builder/README.md
@@ -106,14 +106,14 @@ export class AppComponent {
 query = {
   condition: 'and',
   rules: [
-    {field: 'birthday', operator: '=', value: new Date()}
+    {field: 'birthday', operator: '=', value: (() => { const d = new Date(); d.setHours(0,0,0,0); return d; })()}
   ]
 };
 
 config: QueryBuilderConfig = {
   fields: {
     birthday: {name: 'Birthday', type: 'date', operators: ['=', '<=', '>']
-      defaultValue: (() => return new Date())
+      defaultValue: (() => { const d = new Date(); d.setHours(0,0,0,0); return d; })
     },
   }
 }

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1035,7 +1035,11 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
         return typeof val !== 'string' || !/^\d{2}:\d{2}(:\d{2})?$/.test(val);
       case 'date':
         if (val instanceof Date) {
-          return isNaN(val.getTime());
+          if (isNaN(val.getTime())) {
+            return true;
+          }
+          return val.getHours() !== 0 || val.getMinutes() !== 0
+            || val.getSeconds() !== 0 || val.getMilliseconds() !== 0;
         } else if (typeof val === 'string') {
           return !/^\d{4}-\d{2}-\d{2}$/.test(val) || isNaN(Date.parse(val));
         }


### PR DESCRIPTION
## Summary
- ensure dates do not include time when defaulting fields
- validate `Date` objects with time components as invalid
- update demo to initialise birthday with a date only

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e8495a0a88321a544a3bea1c68175