### PR TITLE
Fix date validation to reject datetime values

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -356,16 +356,7 @@ export class AppComponent implements OnInit {
           }
           break;
         case 'date':
-          if (val instanceof Date) {
-            if (
-              val.getHours() !== 0 ||
-              val.getMinutes() !== 0 ||
-              val.getSeconds() !== 0 ||
-              val.getMilliseconds() !== 0
-            ) {
-              return false;
-            }
-          } else if (typeof val === 'string') {
+          if (typeof val === 'string') {
             if (!/^\d{4}-\d{2}-\d{2}$/.test(val) || isNaN(Date.parse(val))) {
               return false;
             }

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1034,9 +1034,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
       case 'time':
         return typeof val !== 'string' || !/^\d{2}:\d{2}(:\d{2})?$/.test(val);
       case 'date':
-        if (val instanceof Date) {
-          return isNaN(val.getTime());
-        } else if (typeof val === 'string') {
+        if (typeof val === 'string') {
           return !/^\d{4}-\d{2}-\d{2}$/.test(val) || isNaN(Date.parse(val));
         }
         return true;


### PR DESCRIPTION
## Summary
- only treat `YYYY-MM-DD` strings as valid date values
- update demo validation logic to match library logic

## Testing
- `npm test` *(fails: `ng: not found`)*
- `npm run lint` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686e88cd476c8321a31620153f674c65