### PR TITLE
Add named ruleset functionality

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -14,6 +14,8 @@ export class AppComponent implements OnInit {
   public queryTextState: 'valid' | 'invalid-json' | 'invalid-query' = 'valid';
   public queryTitle = '';
 
+  public namedRulesets: Record<string, RuleSet> = {};
+
   public bootstrapClassNames: QueryBuilderClassNames = {
     removeIcon: 'fa fa-minus',
     addIcon: 'fa fa-plus',
@@ -220,6 +222,24 @@ export class AppComponent implements OnInit {
     return null;
   }
 
+  listNamedRulesets(): string[] {
+    return Object.keys(this.namedRulesets);
+  }
+
+  getNamedRuleset(name: string): RuleSet {
+    return JSON.parse(JSON.stringify(this.namedRulesets[name]));
+  }
+
+  saveNamedRuleset(ruleset: RuleSet) {
+    if (ruleset.name) {
+      this.namedRulesets[ruleset.name] = JSON.parse(JSON.stringify(ruleset));
+    }
+  }
+
+  deleteNamedRuleset(name: string) {
+    delete this.namedRulesets[name];
+  }
+
   updateCollapsedSummary() {
     this.currentConfig = {
       ...this.currentConfig,
@@ -231,6 +251,13 @@ export class AppComponent implements OnInit {
     private formBuilder: FormBuilder
   ) {
     this.queryCtrl = this.formBuilder.control(this.query);
+    this.config = {
+      ...this.config,
+      listNamedRulesets: this.listNamedRulesets.bind(this),
+      getNamedRuleset: this.getNamedRuleset.bind(this),
+      saveNamedRuleset: this.saveNamedRuleset.bind(this),
+      deleteNamedRuleset: this.deleteNamedRuleset.bind(this)
+    } as QueryBuilderConfig;
     this.currentConfig = this.config;
     this.updateCollapsedSummary();
     this.queryText = JSON.stringify(this.queryCtrl.value, null, 2);

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -31,6 +31,14 @@
     color: rgb(52 47 167)
   }
 
+  .q-search-icon::before {
+    content: '🔍'
+  }
+
+  .q-save-icon::before {
+    content: '💾'
+  }
+
   .q-up-icon {
     &::before {
       content: '▲';
@@ -302,6 +310,16 @@
     font-style: italic;
     font-weight: 300;
     color: #666;
+    align-self: center;
+    margin-right: 8px;
+  }
+
+  .q-name-text {
+    font-size: 0.75em;
+    font-style: italic;
+    font-weight: 300;
+    color: #666;
+    cursor: pointer;
     align-self: center;
     margin-right: 8px;
   }

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -5,6 +5,8 @@
         <ng-template [ngTemplateOutlet]="_arrowIconTpl"/>
       </a>
 
+      <span *ngIf="!data.name && config.saveNamedRuleset && !isRulesetInvalid(data)" class="q-name-text" (click)="nameRuleset(data)">Click to name {{rulesetName}}</span>
+
       <ng-template [ngTemplateOutlet]="_switchGroupTpl"/>
 
       <ng-template [ngTemplateOutlet]="_buttonGroupTpl"/>
@@ -146,6 +148,10 @@
       <div class="q-buttons">
       <ng-container *ngIf="!config.rulesLimit || data.rules.length < config.rulesLimit">
         <ng-container *ngTemplateOutlet="_rulesetAddRuleButtonTpl"></ng-container>
+        <button *ngIf="config.listNamedRulesets && config.getNamedRuleset" type="button"
+                (click)="addNamedRuleSet()" [ngClass]="getClassNames('button')" [disabled]="disabled">
+          <i [ngClass]="getClassNames('addIcon')"></i> Named {{rulesetName}}
+        </button>
         <ng-container *ngIf="!config.levelLimit || level + 1 < config.levelLimit">
           <ng-container *ngTemplateOutlet="_rulesetAddRulesetButtonTpl"></ng-container>
         </ng-container>
@@ -167,9 +173,13 @@
         </svg>
         {{ruleName}}
       </button>
-        <ng-container *ngIf="!!parentValue">
-          <ng-container *ngTemplateOutlet="_rulesetRemoveButtonTpl"></ng-container>
-        </ng-container>
+      <button *ngIf="data.name && config.getNamedRuleset && config.saveNamedRuleset && config.deleteNamedRuleset" type="button"
+              (click)="namedRulesetAction(data)" [ngClass]="getClassNames('button')" [disabled]="disabled">
+        <i [ngClass]="getClassNames(namedRulesetModified(data) ? 'saveIcon' : 'searchIcon')"></i> {{rulesetName}}: {{data.name}}
+      </button>
+      <ng-container *ngIf="!!parentValue">
+        <ng-container *ngTemplateOutlet="_rulesetRemoveButtonTpl"></ng-container>
+      </ng-container>
       </div>
     </div>
   </ng-template>

--- a/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts
+++ b/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts
@@ -1,6 +1,7 @@
 export interface RuleSet {
   condition: string;
   rules: (RuleSet | Rule)[];
+  name?: string;
   not?: boolean;
   collapsed?: boolean;
   isChild?: boolean;
@@ -85,6 +86,8 @@ export interface QueryBuilderClassNames {
   upIcon?: string;
   downIcon?: string;
   equalIcon?: string;
+  searchIcon?: string;
+  saveIcon?: string;
   collapsedSummary?: string;
 }
 
@@ -106,6 +109,10 @@ export interface QueryBuilderConfig {
                                nextField: Field | undefined,
                                currentValue: any) => any;
   customCollapsedSummary?: (ruleset: RuleSet) => string;
+  listNamedRulesets?: () => string[];
+  getNamedRuleset?: (name: string) => RuleSet;
+  saveNamedRuleset?: (ruleset: RuleSet) => void;
+  deleteNamedRuleset?: (name: string) => void;
 }
 
 export interface SwitchGroupContext {


### PR DESCRIPTION
## Summary
- support `name` on `RuleSet`
- add callbacks for managing named rulesets
- implement UI hooks for inserting and managing named rulesets
- keep demo named rulesets map and wire callbacks

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebc702a0083219b21c10f2ca24447