### PR TITLE
Fix named rulesets demo

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -36,6 +36,9 @@
           <label><input type="checkbox" [(ngModel)]='allowConvertToRuleset'>Allow Convert To Ruleset</label>
         </div>
         <div>
+          <label><input type="checkbox" [(ngModel)]='useSavedRulesets' (change)='updateNamedRulesetsUsage()'>Saved Rulesets</label>
+        </div>
+        <div>
           <label><input type="checkbox" [(ngModel)]='allowRuleUpDown'>Allow Rule Up/Down</label>
         </div>
         <div>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1240,6 +1240,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     const excluded = this.getAncestorNames(parent);
     const names = this.config.listNamedRulesets().filter(n => excluded.indexOf(n) === -1);
     if (names.length === 0) {
+      window.alert('No saved ' + this.rulesetName + 's available.');
       return;
     }
     const selection = window.prompt('Select a Named ' + this.rulesetName + '\n' + names.join('\n'));


### PR DESCRIPTION
## Summary
- add Saved Rulesets toggle in demo
- enable/disable named ruleset callbacks based on the new checkbox
- alert when no saved rulesets exist
- allow `name` property when validating JSON

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ecc567240832187361080b37ba766