### PR TITLE
Refine named rulesets UI

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/add-named-ruleset-dialog.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/add-named-ruleset-dialog.component.ts
@@ -1,0 +1,33 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+export interface AddNamedRulesetDialogData {
+  names: string[];
+  rulesetName: string;
+}
+
+@Component({
+  selector: 'lib-add-named-ruleset-dialog',
+  template: `
+    <h1 mat-dialog-title>Select a Named {{data.rulesetName}}</h1>
+    <div mat-dialog-content>
+      <mat-form-field appearance="fill">
+        <mat-label>{{data.rulesetName}} Name</mat-label>
+        <mat-select [(value)]="selected">
+          <mat-option *ngFor="let n of data.names" [value]="n">{{n}}</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div mat-dialog-actions>
+      <button mat-button (click)="dialogRef.close()">Cancel</button>
+      <button mat-raised-button color="primary" [disabled]="!selected" (click)="dialogRef.close(selected)">Add</button>
+    </div>
+  `
+})
+export class AddNamedRulesetDialogComponent {
+  selected: string | null = null;
+  constructor(
+    public dialogRef: MatDialogRef<AddNamedRulesetDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: AddNamedRulesetDialogData
+  ) {}
+}

--- a/projects/ngx-query-builder/src/lib/components/message-dialog.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/message-dialog.component.ts
@@ -1,0 +1,17 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+@Component({
+  selector: 'lib-message-dialog',
+  template: `
+    <h1 mat-dialog-title>{{data.title}}</h1>
+    <div mat-dialog-content>{{data.message}}</div>
+    <div mat-dialog-actions>
+      <button mat-button [mat-dialog-close]="false" *ngIf="data.confirm">Cancel</button>
+      <button mat-button color="primary" [mat-dialog-close]="true">OK</button>
+    </div>
+  `
+})
+export class MessageDialogComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: { title: string; message: string; confirm?: boolean }) {}
+}

--- a/projects/ngx-query-builder/src/lib/components/named-ruleset-dialog.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/named-ruleset-dialog.component.ts
@@ -1,0 +1,42 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+export interface NamedRulesetDialogData {
+  name: string;
+  rulesetName: string;
+  allowDelete: boolean;
+  modified: boolean;
+}
+
+export interface NamedRulesetDialogResult {
+  action: 'save' | 'delete' | 'cancel';
+  name?: string;
+}
+
+@Component({
+  selector: 'lib-named-ruleset-dialog',
+  template: `
+    <h1 mat-dialog-title>Save {{data.rulesetName}}</h1>
+    <div mat-dialog-content>
+      <mat-form-field appearance="fill">
+        <mat-label>{{data.rulesetName}} Name</mat-label>
+        <input matInput [(ngModel)]="name" />
+      </mat-form-field>
+      <div *ngIf="data.modified" class="q-modified-warning">Existing definition will be updated.</div>
+    </div>
+    <div mat-dialog-actions>
+      <button mat-button (click)="dialogRef.close({action: 'cancel'})">Cancel</button>
+      <button mat-button color="warn" *ngIf="data.allowDelete" (click)="dialogRef.close({action: 'delete'})">Delete</button>
+      <button mat-raised-button color="primary" [disabled]="!name" (click)="dialogRef.close({action: 'save', name})">Save</button>
+    </div>
+  `
+})
+export class NamedRulesetDialogComponent {
+  name: string;
+  constructor(
+    public dialogRef: MatDialogRef<NamedRulesetDialogComponent, NamedRulesetDialogResult>,
+    @Inject(MAT_DIALOG_DATA) public data: NamedRulesetDialogData
+  ) {
+    this.name = data.name;
+  }
+}

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -323,4 +323,20 @@
     align-self: center;
     margin-right: 8px;
   }
+
+  .q-name-edit {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    margin-left: 8px;
+  }
+
+  .q-name-input {
+    font-size: 0.75em;
+    padding: 2px 4px;
+  }
+
+  .q-name-action {
+    margin-left: 8px;
+  }
 }

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -5,9 +5,18 @@
         <ng-template [ngTemplateOutlet]="_arrowIconTpl"/>
       </a>
 
-      <span *ngIf="!data.name && config.saveNamedRuleset && !isRulesetInvalid(data)" class="q-name-text" (click)="nameRuleset(data)">Click to name {{rulesetName}}</span>
-
       <ng-template [ngTemplateOutlet]="_switchGroupTpl"/>
+
+      <span *ngIf="namingRuleset === data" class="q-name-edit">
+        <input [(ngModel)]="namingRulesetName" class="q-name-input" />
+        <button type="button" (click)="confirmNamingRuleset()" [ngClass]="getClassNames('button')">✓</button>
+        <button type="button" (click)="cancelNamingRuleset()" [ngClass]="getClassNames('button')">✕</button>
+      </span>
+      <span *ngIf="!data.name && config.saveNamedRuleset && !isRulesetInvalid(data) && namingRuleset !== data" class="q-name-text" (click)="startNamingRuleset(data)">Click to name {{rulesetName}}</span>
+
+      <button *ngIf="data.name && config.getNamedRuleset && config.saveNamedRuleset && config.deleteNamedRuleset" type="button" class="q-name-action" (click)="namedRulesetAction(data)" [ngClass]="getClassNames('button')" [disabled]="disabled">
+        <i [ngClass]="getClassNames(namedRulesetModified(data) ? 'saveIcon' : 'searchIcon')"></i>
+      </button>
 
       <ng-template [ngTemplateOutlet]="_buttonGroupTpl"/>
     </div>
@@ -172,10 +181,6 @@
           <path d="M1 3h10v2H1zM1 7h10v2H1z"/>
         </svg>
         {{ruleName}}
-      </button>
-      <button *ngIf="data.name && config.getNamedRuleset && config.saveNamedRuleset && config.deleteNamedRuleset" type="button"
-              (click)="namedRulesetAction(data)" [ngClass]="getClassNames('button')" [disabled]="disabled">
-        <i [ngClass]="getClassNames(namedRulesetModified(data) ? 'saveIcon' : 'searchIcon')"></i> {{rulesetName}}: {{data.name}}
       </button>
       <ng-container *ngIf="!!parentValue">
         <ng-container *ngTemplateOutlet="_rulesetRemoveButtonTpl"></ng-container>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.spec.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.spec.ts
@@ -1,7 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
-import { FormsModule, } from '@angular/forms';
+import { FormsModule } from '@angular/forms';
+import { MatDialogModule } from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { QueryBuilderComponent } from './query-builder.component';
+import { AddNamedRulesetDialogComponent } from './add-named-ruleset-dialog.component';
+import { NamedRulesetDialogComponent } from './named-ruleset-dialog.component';
+import { MessageDialogComponent } from './message-dialog.component';
 
 describe('QueryBuilderComponent', () => {
   let component: QueryBuilderComponent;
@@ -9,8 +14,13 @@ describe('QueryBuilderComponent', () => {
 
   beforeEach((() => {
     TestBed.configureTestingModule({
-      imports: [ CommonModule, FormsModule ],
-      declarations: [ QueryBuilderComponent ]
+      imports: [ CommonModule, FormsModule, MatDialogModule, BrowserAnimationsModule ],
+      declarations: [
+        QueryBuilderComponent,
+        AddNamedRulesetDialogComponent,
+        NamedRulesetDialogComponent,
+        MessageDialogComponent
+      ]
     })
     .compileComponents();
   }));

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -50,6 +50,10 @@ import {
   ViewChild,
   ElementRef
 } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { AddNamedRulesetDialogComponent } from './add-named-ruleset-dialog.component';
+import { NamedRulesetDialogComponent, NamedRulesetDialogResult } from './named-ruleset-dialog.component';
+import { MessageDialogComponent } from './message-dialog.component';
 
 export const CONTROL_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -191,8 +195,11 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   private rulesetRemoveButtonContextCache = new Map<Rule, RulesetRemoveButtonContext>();
   private ruleRemoveButtonContextCache = new Map<Rule, RuleRemoveButtonContext>();
   private buttonGroupContext!: ButtonGroupContext;
+  public namingRuleset: RuleSet | null = null;
+  public namingRulesetName = '';
 
-  constructor(private changeDetectorRef: ChangeDetectorRef) { }
+  constructor(private changeDetectorRef: ChangeDetectorRef,
+              private dialog: MatDialog) { }
 
   // ----------OnChanges Implementation----------
 
@@ -1236,21 +1243,26 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     if (this.disabled || !this.config.listNamedRulesets || !this.config.getNamedRuleset) {
       return;
     }
-    parent = parent || this.data;
-    const excluded = this.getAncestorNames(parent);
+    const target = parent || this.data;
+    const excluded = this.getAncestorNames(target);
     const names = this.config.listNamedRulesets().filter(n => excluded.indexOf(n) === -1);
     if (names.length === 0) {
-      window.alert('No saved ' + this.rulesetName + 's available.');
+      this.dialog.open(MessageDialogComponent, {
+        data: { title: 'Named ' + this.rulesetName, message: 'No saved ' + this.rulesetName + 's available.' }
+      });
       return;
     }
-    const selection = window.prompt('Select a Named ' + this.rulesetName + '\n' + names.join('\n'));
-    if (selection && names.includes(selection)) {
-      const rs = JSON.parse(JSON.stringify(this.config.getNamedRuleset!(selection)));
-      this.registerParentRefs(rs, parent);
-      parent.rules.push(rs);
-      this.handleTouched();
-      this.handleDataChange();
-    }
+    this.dialog.open(AddNamedRulesetDialogComponent, {
+      data: { names, rulesetName: this.rulesetName }
+    }).afterClosed().subscribe((selection: string | null) => {
+      if (selection && names.includes(selection)) {
+        const rs = JSON.parse(JSON.stringify(this.config.getNamedRuleset!(selection)));
+        this.registerParentRefs(rs, target);
+        target.rules.push(rs);
+        this.handleTouched();
+        this.handleDataChange();
+      }
+    });
   }
 
   namedRulesetModified(ruleset: RuleSet): boolean {
@@ -1267,47 +1279,66 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
       return;
     }
     const modified = this.namedRulesetModified(ruleset);
-    let msg = 'Rename or delete ' + this.rulesetName + ' "' + ruleset.name + '"';
-    if (modified) { msg += '\nType UPDATE to overwrite existing definition.'; }
-    const result = window.prompt(msg, ruleset.name);
-    if (result === null) { return; }
-    if (result === '') {
-      if (confirm('Delete named ' + this.rulesetName + ' ' + ruleset.name + '?')) {
-        this.config.deleteNamedRuleset(ruleset.name);
-        delete ruleset.name;
-        this.handleTouched();
-        this.handleDataChange();
+    this.dialog.open(NamedRulesetDialogComponent, {
+      data: { name: ruleset.name!, rulesetName: this.rulesetName, allowDelete: true, modified }
+    }).afterClosed().subscribe((result: NamedRulesetDialogResult | undefined) => {
+      if (!result || result.action === 'cancel') { return; }
+      if (result.action === 'delete') {
+        this.dialog.open(MessageDialogComponent, {
+          data: { title: 'Confirm', message: 'Delete named ' + this.rulesetName + ' ' + ruleset.name + '?', confirm: true }
+        }).afterClosed().subscribe((confirmed: boolean) => {
+          if (confirmed) {
+            this.config.deleteNamedRuleset!(ruleset.name!);
+            delete ruleset.name;
+            this.handleTouched();
+            this.handleDataChange();
+          }
+        });
+        return;
       }
-      return;
-    }
-    if (modified && result === 'UPDATE') {
+      const newName = result.name!.trim();
+      if (!this.isValidRulesetName(newName, ruleset)) {
+        this.dialog.open(MessageDialogComponent, { data: { title: 'Invalid name', message: 'Invalid name' } });
+        return;
+      }
+      if (ruleset.name !== newName) {
+        this.config.deleteNamedRuleset(ruleset.name!);
+        ruleset.name = newName;
+      }
       this.config.saveNamedRuleset(ruleset);
+      this.handleTouched();
+      this.handleDataChange();
+    });
+  }
+
+  startNamingRuleset(ruleset: RuleSet = this.data): void {
+    if (!this.config.saveNamedRuleset) { return; }
+    this.namingRuleset = ruleset;
+    this.namingRulesetName = '';
+  }
+
+  confirmNamingRuleset(): void {
+    const ruleset = this.namingRuleset;
+    if (!ruleset) { return; }
+    const name = this.namingRulesetName.trim();
+    if (!this.isValidRulesetName(name)) {
+      this.dialog.open(MessageDialogComponent, {
+        data: { title: 'Invalid name', message: 'Invalid name' }
+      });
       return;
     }
-    const newName = result.trim();
-    if (!this.isValidRulesetName(newName, ruleset)) {
-      alert('Invalid name');
-      return;
+    ruleset.name = name;
+    this.registerParentRefs(ruleset, QueryBuilderComponent.parentMap.get(ruleset) || null);
+    if (this.config.saveNamedRuleset) {
+      this.config.saveNamedRuleset(ruleset);
     }
-    if (ruleset.name !== newName) {
-      this.config.deleteNamedRuleset(ruleset.name);
-      ruleset.name = newName;
-    }
-    this.config.saveNamedRuleset(ruleset);
+    this.namingRuleset = null;
     this.handleTouched();
     this.handleDataChange();
   }
 
-  nameRuleset(ruleset: RuleSet = this.data): void {
-    if (!this.config.saveNamedRuleset) { return; }
-    const name = window.prompt('Enter name for ' + this.rulesetName);
-    if (!name) { return; }
-    if (!this.isValidRulesetName(name)) { alert('Invalid name'); return; }
-    ruleset.name = name;
-    this.registerParentRefs(ruleset, QueryBuilderComponent.parentMap.get(ruleset) || null);
-    this.config.saveNamedRuleset(ruleset);
-    this.handleTouched();
-    this.handleDataChange();
+  cancelNamingRuleset(): void {
+    this.namingRuleset = null;
   }
 
 }

--- a/projects/ngx-query-builder/src/lib/query-builder.module.ts
+++ b/projects/ngx-query-builder/src/lib/query-builder.module.ts
@@ -1,6 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule, } from '@angular/forms';
+import { FormsModule } from '@angular/forms';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSelectModule } from '@angular/material/select';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
 
 import { QueryBuilderComponent } from './components/query-builder.component';
 
@@ -16,11 +21,19 @@ import { QueryRulesetAddRulesetButtonDirective } from './directives/query-rulese
 import { QueryRulesetRemoveButtonDirective } from './directives/query-ruleset-remove-button.directive';
 import { QueryRuleRemoveButtonDirective } from './directives/query-rule-remove-button.directive';
 import { QueryEmptyWarningDirective } from './directives/query-empty-warning.directive';
+import { AddNamedRulesetDialogComponent } from './components/add-named-ruleset-dialog.component';
+import { NamedRulesetDialogComponent } from './components/named-ruleset-dialog.component';
+import { MessageDialogComponent } from './components/message-dialog.component';
 
 @NgModule({
   imports: [
     CommonModule,
-    FormsModule
+    FormsModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatSelectModule,
+    MatInputModule,
+    MatFormFieldModule
   ],
   declarations: [
     QueryBuilderComponent,
@@ -35,7 +48,10 @@ import { QueryEmptyWarningDirective } from './directives/query-empty-warning.dir
     QueryRulesetRemoveButtonDirective,
     QueryRuleRemoveButtonDirective,
     QueryEmptyWarningDirective,
-    QueryArrowIconDirective
+    QueryArrowIconDirective,
+    AddNamedRulesetDialogComponent,
+    NamedRulesetDialogComponent,
+    MessageDialogComponent
   ],
   exports: [
     QueryBuilderComponent,


### PR DESCRIPTION
## Summary
- add Angular Material dialog components
- import Material modules and wire up dialogs
- support inline ruleset naming
- move named ruleset button next to switch buttons
- update spec for new dependencies

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed3296de48321b37fefb0300b9cbc