### PR TITLE
Improve ruleset naming interactions

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -334,6 +334,13 @@
   .q-name-input {
     font-size: 0.75em;
     padding: 2px 4px;
+    border: 1px solid #bbb;
+  }
+
+  .q-name-edit .q-button {
+    border: none;
+    padding: 0 4px;
+    font-size: 0.75em;
   }
 
   .q-name-action {

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -8,7 +8,7 @@
       <ng-template [ngTemplateOutlet]="_switchGroupTpl"/>
 
       <span *ngIf="namingRuleset === data" class="q-name-edit">
-        <input [(ngModel)]="namingRulesetName" class="q-name-input" />
+        <input [(ngModel)]="namingRulesetName" class="q-name-input" (input)="onNamingInput($event)" />
         <button type="button" (click)="confirmNamingRuleset()" [ngClass]="getClassNames('button')">✓</button>
         <button type="button" (click)="cancelNamingRuleset()" [ngClass]="getClassNames('button')">✕</button>
       </span>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1216,6 +1216,10 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     }
   }
 
+  private cloneRuleset(ruleset: RuleSet): RuleSet {
+    return JSON.parse(JSON.stringify(ruleset));
+  }
+
   private getAncestorNames(ruleset: RuleSet | null): string[] {
     const names: string[] = [];
     let current = ruleset;
@@ -1256,7 +1260,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
       data: { names, rulesetName: this.rulesetName }
     }).afterClosed().subscribe((selection: string | null) => {
       if (selection && names.includes(selection)) {
-        const rs = JSON.parse(JSON.stringify(this.config.getNamedRuleset!(selection)));
+        const rs = this.cloneRuleset(this.config.getNamedRuleset!(selection));
         this.registerParentRefs(rs, target);
         target.rules.push(rs);
         this.handleTouched();
@@ -1305,7 +1309,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
         this.config.deleteNamedRuleset!(ruleset.name!);
         ruleset.name = newName;
       }
-      this.config.saveNamedRuleset!(ruleset);
+      this.config.saveNamedRuleset!(this.cloneRuleset(ruleset));
       this.handleTouched();
       this.handleDataChange();
     });
@@ -1330,11 +1334,16 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     ruleset.name = name;
     this.registerParentRefs(ruleset, QueryBuilderComponent.parentMap.get(ruleset) || null);
     if (this.config.saveNamedRuleset) {
-      this.config.saveNamedRuleset(ruleset);
+      this.config.saveNamedRuleset(this.cloneRuleset(ruleset));
     }
     this.namingRuleset = null;
     this.handleTouched();
     this.handleDataChange();
+  }
+
+  onNamingInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.namingRulesetName = input.value.toUpperCase().replace(/[^A-Z0-9_]/g, '');
   }
 
   cancelNamingRuleset(): void {


### PR DESCRIPTION
## Summary
- refine ruleset naming input and buttons
- clone rulesets when saving named rulesets
- validate name characters during typing

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686edb95dbe8832183866b5b591a592f