### PR TITLE
Add named ruleset improvements

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/named-ruleset-dialog.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/named-ruleset-dialog.component.ts
@@ -9,7 +9,7 @@ export interface NamedRulesetDialogData {
 }
 
 export interface NamedRulesetDialogResult {
-  action: 'save' | 'delete' | 'cancel';
+  action: 'save' | 'delete' | 'cancel' | 'removeName';
   name?: string;
 }
 
@@ -28,6 +28,7 @@ export interface NamedRulesetDialogResult {
     <div mat-dialog-actions>
       <button mat-button (click)="dialogRef.close({action: 'cancel'})">Cancel</button>
       <button mat-button color="warn" *ngIf="data.allowDelete" (click)="dialogRef.close({action: 'delete'})">Delete</button>
+      <button mat-button color="warn" (click)="dialogRef.close({action: 'removeName'})">Remove Name</button>
       <button mat-raised-button color="primary" [disabled]="!name" (click)="dialogRef.close({action: 'save', name})">Save</button>
     </div>
   `

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -346,4 +346,16 @@
   .q-name-action {
     margin-left: 8px;
   }
+
+  .q-name-label {
+    font-size: 0.75em;
+    font-style: italic;
+    font-weight: 300;
+    color: #666;
+    margin-left: 4px;
+  }
+
+  .q-name-modified {
+    font-weight: bold;
+  }
 }

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -14,8 +14,9 @@
       </span>
       <span *ngIf="!data.name && config.saveNamedRuleset && !isRulesetInvalid(data) && namingRuleset !== data" class="q-name-text" (click)="startNamingRuleset(data)">Click to name {{rulesetName}}</span>
 
-      <button *ngIf="data.name && config.getNamedRuleset && config.saveNamedRuleset && config.deleteNamedRuleset" type="button" class="q-name-action" (click)="namedRulesetAction(data)" [ngClass]="getClassNames('button')" [disabled]="disabled">
+      <button *ngIf="data.name && config.getNamedRuleset && config.saveNamedRuleset && config.deleteNamedRuleset" type="button" class="q-name-action" (click)="namedRulesetAction(data)" [ngClass]="getClassNames('button')" [disabled]="disabled" [title]="namedRulesetModified(data) ? rulesetName + ' has been modified needs to be saved, renamed or unnamed' : null">
         <i [ngClass]="getClassNames(namedRulesetModified(data) ? 'saveIcon' : 'searchIcon')"></i>
+        <span class="q-name-label" [ngClass]="{'q-name-modified': namedRulesetModified(data)}">{{data.name}}</span>
       </button>
 
       <ng-template [ngTemplateOutlet]="_buttonGroupTpl"/>


### PR DESCRIPTION
## Summary
- display ruleset names on the named ruleset button
- flag modified named rulesets as invalid
- allow removing a ruleset name
- sync changes/renames across all named rulesets
- style named ruleset labels

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run lint --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee723192483218e6aa24c363a5cac