### PR TITLE
Fix named query instance updates

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1224,8 +1224,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   }
 
   private updateNamedRulesetInstances(name: string, source: RuleSet, skip?: RuleSet): void {
-    const walk = (rs: RuleSet) => {
-      const parent = QueryBuilderComponent.parentMap.get(rs) || null;
+    const walk = (rs: RuleSet, parent: RuleSet | null) => {
       if (rs !== skip && rs.name === name) {
         const clone = this.cloneRuleset(source);
         clone.name = name;
@@ -1241,17 +1240,16 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
       if (rs.rules) {
         rs.rules.forEach(child => {
           if (this.isRuleset(child)) {
-            walk(child);
+            walk(child, rs);
           }
         });
       }
     };
-    walk(this.data);
+    walk(this.data, null);
   }
 
   private renameNamedRulesetInstances(oldName: string, newName: string, source: RuleSet, skip?: RuleSet): void {
-    const walk = (rs: RuleSet) => {
-      const parent = QueryBuilderComponent.parentMap.get(rs) || null;
+    const walk = (rs: RuleSet, parent: RuleSet | null) => {
       if (rs !== skip && rs.name === oldName) {
         const clone = this.cloneRuleset(source);
         clone.name = newName;
@@ -1267,12 +1265,12 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
       if (rs.rules) {
         rs.rules.forEach(child => {
           if (this.isRuleset(child)) {
-            walk(child);
+            walk(child, rs);
           }
         });
       }
     };
-    walk(this.data);
+    walk(this.data, null);
   }
 
   private renameCreatesCycle(oldName: string, newName: string): boolean {


### PR DESCRIPTION
## Summary
- fix named ruleset update logic to properly traverse tree

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eecd30ee48321862a7c0eafb30585