### PR TITLE
Fix named ruleset updates

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1405,8 +1405,11 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
         this.config.deleteNamedRuleset!(oldName);
         ruleset.name = newName;
       }
-      this.updateNamedRulesetInstances(newName, ruleset, ruleset);
       this.config.saveNamedRuleset!(this.cloneRuleset(ruleset));
+      if (this.config.getNamedRuleset) {
+        const saved = this.config.getNamedRuleset(newName);
+        this.updateNamedRulesetInstances(newName, saved);
+      }
       this.handleTouched();
       this.handleDataChange();
     });


### PR DESCRIPTION
## Summary
- update existing named rulesets after saving via the persisted copy

## Testing
- `npx ng lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686faa69c32483219f373bdd06491743