### PR TITLE
Fix query tree not updating after named ruleset save

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1259,6 +1259,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
       }
     };
     walk(this.data);
+    this.changeDetectorRef.detectChanges();
   }
 
   private renameNamedRulesetInstances(oldName: string, newName: string, source: RuleSet, skip?: RuleSet): void {
@@ -1285,6 +1286,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
       }
     };
     walk(this.data);
+    this.changeDetectorRef.detectChanges();
   }
 
   private renameCreatesCycle(oldName: string, newName: string): boolean {


### PR DESCRIPTION
## Summary
- call `detectChanges` after refreshing named ruleset instances

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb3de9c608321bab03842be0af5e8