### PR TITLE
Fix UI refresh when underlying query data changes

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1089,7 +1089,11 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   }
 
   private handleDataChange(): void {
-    this.changeDetectorRef.markForCheck();
+    // Force Angular to immediately update the view when the underlying
+    // query data changes. Using `detectChanges` ensures that updates
+    // originating outside the normal zone execution (such as dialog
+    // callbacks) properly refresh the UI in the same tick.
+    this.changeDetectorRef.detectChanges();
     if (this.onChangeCallback) {
       this.onChangeCallback();
     }


### PR DESCRIPTION
## Summary
- ensure the query builder component forces view updates when data is mutated

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb86f79088321b2f8e28e942b107f