### PR TITLE
Update ruleset naming dialog

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/named-ruleset-dialog.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/named-ruleset-dialog.component.ts
@@ -17,18 +17,18 @@ export interface NamedRulesetDialogResult {
   selector: 'lib-named-ruleset-dialog',
   standalone: false,
   template: `
-    <h1 mat-dialog-title>Save {{data.rulesetName}}</h1>
+    <h1 mat-dialog-title>Update {{data.rulesetName}}</h1>
     <div mat-dialog-content>
       <mat-form-field appearance="fill">
         <mat-label>{{data.rulesetName}} Name</mat-label>
-        <input matInput [(ngModel)]="name" />
+        <input matInput [(ngModel)]="name" (input)="onInput($event)" />
+        <button mat-icon-button matSuffix *ngIf="name" (click)="name = ''" type="button">✕</button>
       </mat-form-field>
       <div *ngIf="data.modified" class="q-modified-warning">Existing definition will be updated.</div>
     </div>
     <div mat-dialog-actions>
       <button mat-button (click)="dialogRef.close({action: 'cancel'})">Cancel</button>
-      <button mat-button color="warn" (click)="dialogRef.close({action: 'removeName'})">Remove Name</button>
-      <button mat-raised-button color="primary" [disabled]="!name" (click)="dialogRef.close({action: 'save', name})">Save</button>
+      <button mat-raised-button color="primary" (click)="dialogRef.close({action: 'save', name})">Update</button>
     </div>
   `
 })
@@ -39,5 +39,10 @@ export class NamedRulesetDialogComponent {
     @Inject(MAT_DIALOG_DATA) public data: NamedRulesetDialogData
   ) {
     this.name = data.name;
+  }
+
+  onInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.name = input.value.toUpperCase().replace(/ /g, '_').replace(/[^A-Z0-9_]/g, '');
   }
 }

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1413,17 +1413,17 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
       data: { name: ruleset.name!, rulesetName: this.rulesetName, allowDelete: true, modified }
     }).afterClosed().subscribe((result: NamedRulesetDialogResult | undefined) => {
       if (!result || result.action === 'cancel') { return; }
-      if (result.action === 'removeName') {
+      if (result.action === 'removeName' || !result.name || result.name.trim() === '') {
         const name = ruleset.name as string;
         delete ruleset.name;
-        if (!this.isRulesetNameInUse(name, this.getRootRuleset(ruleset))){
+        if (!this.isRulesetNameInUse(name, this.getRootRuleset(ruleset))) {
           this.config.deleteNamedRuleset!(name);
         }
         this.handleTouched();
         this.handleDataChange();
         return;
       }
-      const newName = result.name!.trim();
+      const newName = result.name.trim();
       if (!this.isValidRulesetName(newName, ruleset)) {
         this.dialog.open(MessageDialogComponent, { data: { title: 'Invalid name', message: 'Invalid name' } });
         return;
@@ -1467,7 +1467,10 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
 
   onNamingInput(event: Event): void {
     const input = event.target as HTMLInputElement;
-    this.namingRulesetName = input.value.toUpperCase().replace(/[^A-Z0-9_]/g, '');
+    this.namingRulesetName = input.value
+      .toUpperCase()
+      .replace(/ /g, '_')
+      .replace(/[^A-Z0-9_]/g, '');
   }
 
   cancelNamingRuleset(): void {


### PR DESCRIPTION
## Summary
- rename "Save Ruleset" dialog to use **Update** wording
- add input filtering and clear button in the dialog
- allow empty name to remove a named ruleset
- normalize ruleset name input with underscores

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687002c771588321b0983e54da964fb3