### PR TITLE
Fix named ruleset dialog options

### DIFF
--- a/projects/ngx-query-builder-demo/src/styles.less
+++ b/projects/ngx-query-builder-demo/src/styles.less
@@ -1,3 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
+@import '~@angular/material/prebuilt-themes/indigo-pink.css';
 
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1375,7 +1375,10 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     }
     const target = parent || this.data;
     const excluded = this.getAncestorNames(target);
-    const names = this.config.listNamedRulesets().filter(n => excluded.indexOf(n) === -1);
+    const names = this.config
+      .listNamedRulesets()
+      .filter(n => excluded.indexOf(n) === -1)
+      .sort();
     if (names.length === 0) {
       this.dialog.open(MessageDialogComponent, {
         data: { title: 'Named ' + this.rulesetName, message: 'No saved ' + this.rulesetName + 's available.' }


### PR DESCRIPTION
## Summary
- sort the names displayed when adding a named ruleset
- include Angular Material prebuilt theme in demo styles

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870071556dc83219b6db17351d0c556