### PR TITLE
Fix angular material theme import

### DIFF
--- a/projects/ngx-query-builder-demo/src/styles.less
+++ b/projects/ngx-query-builder-demo/src/styles.less
@@ -1,4 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
-@import '~@angular/material/prebuilt-themes/indigo-pink.css';
+@import '@angular/material/prebuilt-themes/indigo-pink.css';
 
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }


### PR DESCRIPTION
## Summary
- fix the angular Material theme import path in the demo's global styles

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm ci` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687009847c448321a4d1099def6aa9ba