### PR TITLE
Implement confirm prompt for deleting unused named rulesets

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1419,11 +1419,26 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
       if (result.action === 'removeName' || !result.name || result.name.trim() === '') {
         const name = ruleset.name as string;
         delete ruleset.name;
+        const finalize = () => {
+          this.handleTouched();
+          this.handleDataChange();
+        };
         if (!this.isRulesetNameInUse(name, this.getRootRuleset(ruleset))) {
-          this.config.deleteNamedRuleset!(name);
+          this.dialog.open(MessageDialogComponent, {
+            data: {
+              title: 'Delete Named ' + this.rulesetName + '?',
+              message: `The ${this.rulesetName} named "${name}" is no longer being used. Delete it?`,
+              confirm: true
+            }
+          }).afterClosed().subscribe((confirmDelete: boolean) => {
+            if (confirmDelete) {
+              this.config.deleteNamedRuleset!(name);
+            }
+            finalize();
+          });
+        } else {
+          finalize();
         }
-        this.handleTouched();
-        this.handleDataChange();
         return;
       }
       const newName = result.name.trim();


### PR DESCRIPTION
## Summary
- ask for confirmation before deleting unused named rulesets

## Testing
- `npm test` *(fails: `ng: not found`)*
- `npm run lint` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687018c327b88321bdac19b0a8c046db