### PR TITLE
Implement automatic named ruleset storing

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.spec.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.spec.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { QueryBuilderComponent } from './query-builder.component';
+import { RuleSet } from '../models/query-builder.interfaces';
 import { AddNamedRulesetDialogComponent } from './add-named-ruleset-dialog.component';
 import { NamedRulesetDialogComponent } from './named-ruleset-dialog.component';
 import { MessageDialogComponent } from './message-dialog.component';
@@ -33,5 +34,24 @@ describe('QueryBuilderComponent', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should save unstored named rulesets when value is set', () => {
+    const save = jasmine.createSpy('save');
+    const list = jasmine.createSpy('list').and.returnValue([]);
+    component.config = { fields: {}, saveNamedRuleset: save, listNamedRulesets: list } as any;
+    const query: RuleSet = {
+      condition: 'and',
+      rules: [
+        { field: 'a', operator: '=' },
+        { condition: 'and', rules: [{ field: 'b', operator: '=' }], name: 'INNER' }
+      ],
+      name: 'ROOT'
+    };
+    component.value = query;
+    expect(save.calls.count()).toBe(2);
+    const names = save.calls.allArgs().map(a => a[0].name);
+    expect(names).toContain('ROOT');
+    expect(names).toContain('INNER');
   });
 });


### PR DESCRIPTION
## Summary
- automatically save unstored named rulesets when a JSON value is loaded
- test auto-saving of named rulesets

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68701df985f8832196f51378ff31cc9d