### PR TITLE
UI improvements for named ruleset buttons

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -347,6 +347,10 @@
     margin-left: 8px;
   }
 
+  .q-name-action-modified {
+    border: 2px solid #B3415D;
+  }
+
   .q-name-label {
     font-size: 0.75em;
     font-style: italic;

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -14,7 +14,7 @@
       </span>
       <span *ngIf="!data.name && config.saveNamedRuleset && !isRulesetInvalid(data) && namingRuleset !== data" class="q-name-text" (click)="startNamingRuleset(data)">Click to name {{rulesetName}}</span>
 
-      <button *ngIf="data.name && config.getNamedRuleset && config.saveNamedRuleset && config.deleteNamedRuleset" type="button" class="q-name-action" (click)="namedRulesetAction(data)" [ngClass]="[getClassNames('button'), namedRulesetModified(data) ? 'q-name-action-modified' : null]" [disabled]="disabled" [title]="namedRulesetModified(data) ? rulesetName + ' has been modified needs to be saved, renamed or unnamed' : null">
+      <button *ngIf="data.name && config.getNamedRuleset && config.saveNamedRuleset && config.deleteNamedRuleset" type="button" class="q-name-action" (click)="namedRulesetAction(data)" [ngClass]="getClassNames('button')" [disabled]="disabled" [title]="namedRulesetModified(data) ? rulesetName + ' has been modified needs to be saved, renamed or unnamed' : null">
         <i [ngClass]="getClassNames(namedRulesetModified(data) ? 'saveIcon' : 'searchIcon')"></i>
         <span class="q-name-label" [ngClass]="{'q-name-modified': namedRulesetModified(data)}">{{data.name}}</span>
       </button>

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -14,11 +14,14 @@
       </span>
       <span *ngIf="!data.name && config.saveNamedRuleset && !isRulesetInvalid(data) && namingRuleset !== data" class="q-name-text" (click)="startNamingRuleset(data)">Click to name {{rulesetName}}</span>
 
-      <button *ngIf="data.name && config.getNamedRuleset && config.saveNamedRuleset && config.deleteNamedRuleset" type="button" class="q-name-action" (click)="namedRulesetAction(data)" [ngClass]="getClassNames('button')" [disabled]="disabled" [title]="namedRulesetModified(data) ? rulesetName + ' has been modified needs to be saved, renamed or unnamed' : null">
+      <button *ngIf="data.name && config.getNamedRuleset && config.saveNamedRuleset && config.deleteNamedRuleset" type="button" class="q-name-action" (click)="namedRulesetAction(data)" [ngClass]="[getClassNames('button'), namedRulesetModified(data) ? 'q-name-action-modified' : null]" [disabled]="disabled" [title]="namedRulesetModified(data) ? rulesetName + ' has been modified needs to be saved, renamed or unnamed' : null">
         <i [ngClass]="getClassNames(namedRulesetModified(data) ? 'saveIcon' : 'searchIcon')"></i>
         <span class="q-name-label" [ngClass]="{'q-name-modified': namedRulesetModified(data)}">{{data.name}}</span>
       </button>
 
+      <span *ngIf="collapsed && config.customCollapsedSummary" [ngClass]="getClassNames('collapsedSummary')">
+        {{ config.customCollapsedSummary(data) }}
+      </span>
       <ng-template [ngTemplateOutlet]="_buttonGroupTpl"/>
     </div>
 
@@ -136,9 +139,6 @@
           <ng-template #blankOr><span class="q-switch-label-empty">OR</span></ng-template>
         </label>
       </div>
-      <span *ngIf="collapsed && config.customCollapsedSummary" [ngClass]="getClassNames('collapsedSummary')">
-        {{ config.customCollapsedSummary(data) }}
-      </span>
     </div>
   </ng-template>
 </ng-template>
@@ -158,13 +158,13 @@
       <div class="q-buttons">
       <ng-container *ngIf="!config.rulesLimit || data.rules.length < config.rulesLimit">
         <ng-container *ngTemplateOutlet="_rulesetAddRuleButtonTpl"></ng-container>
+        <ng-container *ngIf="!config.levelLimit || level + 1 < config.levelLimit">
+          <ng-container *ngTemplateOutlet="_rulesetAddRulesetButtonTpl"></ng-container>
+        </ng-container>
         <button *ngIf="config.listNamedRulesets && config.getNamedRuleset" type="button"
                 (click)="addNamedRuleSet()" [ngClass]="getClassNames('button')" [disabled]="disabled">
           <i [ngClass]="getClassNames('addIcon')"></i> Named {{rulesetName}}
         </button>
-        <ng-container *ngIf="!config.levelLimit || level + 1 < config.levelLimit">
-          <ng-container *ngTemplateOutlet="_rulesetAddRulesetButtonTpl"></ng-container>
-        </ng-container>
       </ng-container>
       <ng-container *ngIf="allowRuleUpDown && parentValue && parentValue.rules.length > 1">
         <button type="button" (click)="moveRuleUp(data, parentValue)" [ngClass]="getClassNames('button')"


### PR DESCRIPTION
## Summary
- move collapsed summary after the named ruleset button
- highlight modified named rulesets
- reorder add buttons so `+ Ruleset` comes before `+ Named Ruleset`

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702b72d34c8321aaed811d296da1a9