### PR TITLE
Add ruleset name sanitizer support

### DIFF
--- a/projects/ngx-query-builder/README.md
+++ b/projects/ngx-query-builder/README.md
@@ -140,6 +140,7 @@ config: QueryBuilderConfig = {
 |`persistValueOnFieldChange`| `boolean`                                                                                                                                                                   |Optional| `false`                          | If `true`, when a field changes to another of the same type, and the type is one of: string, number, time, date, or boolean, persist the previous value. This option is ignored if config.calculateFieldChangeValue is provided. |
 |`config.calculateFieldChangeValue`| `(currentField: Field, nextField: Field, currentValue: any) => any`                                                                                                         |Optional|                                  | Used to calculate the new value when a rule's field changes. |
 |`config.customCollapsedSummary`| `(ruleset: RuleSet) => string` |Optional| | Generates a custom summary string when a ruleset is collapsed. |
+|`config.rulesetNameSanitizer`| `(value: string) => string` |Optional| | Sanitizes the name when naming or updating a ruleset. Defaults to `value.toUpperCase().replace(/ /g, '_').replace(/[^A-Z0-9_]/g, '')`. |
 |`value`| [`Ruleset`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts)                                                                                         |Optional| { condition: 'and', rules: [] }  | Object that stores the state of the component. |
 
 ## Structural Directives

--- a/projects/ngx-query-builder/src/lib/components/named-ruleset-dialog.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/named-ruleset-dialog.component.ts
@@ -6,6 +6,7 @@ export interface NamedRulesetDialogData {
   rulesetName: string;
   allowDelete: boolean;
   modified: boolean;
+  rulesetNameSanitizer?: (value: string) => string;
 }
 
 export interface NamedRulesetDialogResult {
@@ -24,7 +25,9 @@ export interface NamedRulesetDialogResult {
         <input matInput [(ngModel)]="name" (input)="onInput($event)" />
         <button mat-icon-button matSuffix *ngIf="name" (click)="name = ''" type="button">✕</button>
       </mat-form-field>
-      <div *ngIf="data.modified" class="q-modified-warning">Existing definition will be updated.</div>
+      <div *ngIf="data.modified" class="q-modified-warning">
+        {{ name.trim() === '' ? 'The name will be removed from the ' + data.rulesetName : 'Existing definition will be updated.' }}
+      </div>
     </div>
     <div mat-dialog-actions>
       <button mat-button (click)="dialogRef.close({action: 'cancel'})">Cancel</button>
@@ -43,6 +46,8 @@ export class NamedRulesetDialogComponent {
 
   onInput(event: Event): void {
     const input = event.target as HTMLInputElement;
-    this.name = input.value.toUpperCase().replace(/ /g, '_').replace(/[^A-Z0-9_]/g, '');
+    const sanitizer = this.data.rulesetNameSanitizer ||
+      ((v: string) => v.toUpperCase().replace(/ /g, '_').replace(/[^A-Z0-9_]/g, ''));
+    this.name = sanitizer(input.value);
   }
 }

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1438,7 +1438,13 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     }
     const modified = this.namedRulesetModified(ruleset);
     this.dialog.open(NamedRulesetDialogComponent, {
-      data: { name: ruleset.name!, rulesetName: this.rulesetName, allowDelete: true, modified }
+      data: {
+        name: ruleset.name!,
+        rulesetName: this.rulesetName,
+        allowDelete: true,
+        modified,
+        rulesetNameSanitizer: this.config.rulesetNameSanitizer
+      }
     }).afterClosed().subscribe((result: NamedRulesetDialogResult | undefined) => {
       if (!result || result.action === 'cancel') { return; }
       if (result.action === 'removeName' || !result.name || result.name.trim() === '') {
@@ -1510,10 +1516,9 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
 
   onNamingInput(event: Event): void {
     const input = event.target as HTMLInputElement;
-    this.namingRulesetName = input.value
-      .toUpperCase()
-      .replace(/ /g, '_')
-      .replace(/[^A-Z0-9_]/g, '');
+    const sanitizer = this.config.rulesetNameSanitizer ||
+      ((v: string) => v.toUpperCase().replace(/ /g, '_').replace(/[^A-Z0-9_]/g, ''));
+    this.namingRulesetName = sanitizer(input.value);
   }
 
   cancelNamingRuleset(): void {

--- a/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts
+++ b/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts
@@ -113,6 +113,7 @@ export interface QueryBuilderConfig {
   getNamedRuleset?: (name: string) => RuleSet;
   saveNamedRuleset?: (ruleset: RuleSet) => void;
   deleteNamedRuleset?: (name: string) => void;
+  rulesetNameSanitizer?: (value: string) => string;
 }
 
 export interface SwitchGroupContext {


### PR DESCRIPTION
## Summary
- allow custom sanitizer for ruleset names via `config.rulesetNameSanitizer`
- show message about removing the name if cleared in Named Ruleset dialog

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68703f09fa108321a119bae58e66db14