### PR TITLE
Enhance named ruleset dialog

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/named-ruleset-dialog.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/named-ruleset-dialog.component.ts
@@ -10,7 +10,7 @@ export interface NamedRulesetDialogData {
 }
 
 export interface NamedRulesetDialogResult {
-  action: 'save' | 'delete' | 'cancel' | 'removeName';
+  action: 'save' | 'delete' | 'cancel' | 'removeName' | 'undo';
   name?: string;
 }
 
@@ -25,13 +25,20 @@ export interface NamedRulesetDialogResult {
         <input matInput [(ngModel)]="name" (input)="onInput($event)" />
         <button mat-icon-button matSuffix *ngIf="name" (click)="name = ''" type="button">✕</button>
       </mat-form-field>
+      <div *ngIf="name.trim() === ''" class="q-modified-warning">
+        The name will be removed from the {{data.rulesetName}}
+      </div>
+      <div *ngIf="name.trim() !== '' && name.trim() !== data.name" class="q-modified-warning">
+        All instances of {{data.name}} will be renamed to {{name.trim()}}
+      </div>
       <div *ngIf="data.modified" class="q-modified-warning">
-        {{ name.trim() === '' ? 'The name will be removed from the ' + data.rulesetName : 'Existing definition will be updated.' }}
+        Existing definition will be updated.
       </div>
     </div>
     <div mat-dialog-actions>
       <button mat-button (click)="dialogRef.close({action: 'cancel'})">Cancel</button>
-      <button mat-raised-button color="primary" (click)="dialogRef.close({action: 'save', name})">Update</button>
+      <button mat-button *ngIf="data.modified" (click)="dialogRef.close({action: 'undo'})">Undo</button>
+      <button mat-raised-button color="primary" [disabled]="isUpdateDisabled()" (click)="dialogRef.close({action: 'save', name})">Update</button>
     </div>
   `
 })
@@ -49,5 +56,9 @@ export class NamedRulesetDialogComponent {
     const sanitizer = this.data.rulesetNameSanitizer ||
       ((v: string) => v.toUpperCase().replace(/ /g, '_').replace(/[^A-Z0-9_]/g, ''));
     this.name = sanitizer(input.value);
+  }
+
+  isUpdateDisabled(): boolean {
+    return !this.data.modified && this.name.trim() === this.data.name;
   }
 }

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1447,6 +1447,22 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
       }
     }).afterClosed().subscribe((result: NamedRulesetDialogResult | undefined) => {
       if (!result || result.action === 'cancel') { return; }
+      if (result.action === 'undo') {
+        try {
+          const stored = this.config.getNamedRuleset!(ruleset.name!);
+          if (stored) {
+            const clone = this.cloneRuleset(stored);
+            Object.keys(ruleset).forEach(k => delete (ruleset as any)[k]);
+            Object.assign(ruleset, clone);
+            this.registerParentRefs(ruleset, QueryBuilderComponent.parentMap.get(ruleset) || null);
+          }
+        } catch {
+          // ignore errors restoring from store
+        }
+        this.handleTouched();
+        this.handleDataChange();
+        return;
+      }
       if (result.action === 'removeName' || !result.name || result.name.trim() === '') {
         const name = ruleset.name as string;
         delete ruleset.name;


### PR DESCRIPTION
## Summary
- improve NamedRulesetDialogComponent with rename/removal messages
- disable update button when nothing changed
- add Undo action when named ruleset modified
- handle Undo action in QueryBuilderComponent

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687045d59ef883218b36b1b059cc2491