### PR TITLE
Add default rule setting and UI tweaks

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.html
+++ b/projects/ngx-query-builder-demo/src/app/app.component.html
@@ -1,6 +1,6 @@
 <main class="main">
   <div class="content">
-    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [allowConvertToRuleset]='allowConvertToRuleset' [allowRuleUpDown]='allowRuleUpDown' [persistValueOnFieldChange]='persistValueOnFieldChange' [ruleName]='ruleName' [rulesetName]='rulesetName' [hideButtons]='hideButtons'>
+    <ngx-query-builder [formControl]='queryCtrl' [config]='currentConfig' [allowRuleset]='allowRuleset' [allowCollapse]='allowCollapse' [allowNot]='allowNot' [allowConvertToRuleset]='allowConvertToRuleset' [allowRuleUpDown]='allowRuleUpDown' [persistValueOnFieldChange]='persistValueOnFieldChange' [ruleName]='ruleName' [rulesetName]='rulesetName' [defaultRuleAttribute]="'name'" [hideButtons]='hideButtons'>
       <ng-container *queryInput="let rule; type: 'textarea'; let getDisabledState=getDisabledState; let onChange=onChange">
       <textarea class="text-input text-area" [(ngModel)]="rule.value" (ngModelChange)="onChange()" [disabled]=getDisabledState()
                 placeholder="Custom Textarea"></textarea>

--- a/projects/ngx-query-builder/README.md
+++ b/projects/ngx-query-builder/README.md
@@ -130,6 +130,7 @@ config: QueryBuilderConfig = {
 |`allowRuleUpDown`| `boolean` |Optional| `false` | Displays up and down arrows on rules and nested rulesets for reordering. |
 |`ruleName`| `string` |Optional| `'Rule'` | Label used in default buttons for rules. |
 |`rulesetName`| `string` |Optional| `'Ruleset'` | Label used in default buttons for rulesets. |
+|`defaultRuleAttribute`| `string` |Optional| | Name of the field to use as the default when adding new rules. |
 |`allowNot`| `boolean` |Optional| `false`                          | Adds a `NOT` button and sets a `not` attribute on the ruleset JSON. |
 |`classNames`| [`QueryBuilderClassNames`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L48)                                                                      |Optional|                                  | CSS class names for different child elements in `query-builder` component. |
 |`config`| [`QueryBuilderConfig`](/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts#L85)                                                                          |Required|                                  | Configuration object for the main component. |

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -349,6 +349,7 @@
 
   .q-name-action-modified {
     border: 2px solid #B3415D;
+    background: rgba(179, 65, 93, 0.1);
   }
 
   .q-name-label {

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -14,7 +14,7 @@
       </span>
       <span *ngIf="!data.name && config.saveNamedRuleset && !isRulesetInvalid(data) && namingRuleset !== data" class="q-name-text" (click)="startNamingRuleset(data)">Click to name {{rulesetName}}</span>
 
-      <button *ngIf="data.name && config.getNamedRuleset && config.saveNamedRuleset && config.deleteNamedRuleset" type="button" class="q-name-action" (click)="namedRulesetAction(data)" [ngClass]="getClassNames('button')" [disabled]="disabled" [title]="namedRulesetModified(data) ? rulesetName + ' has been modified needs to be saved, renamed or unnamed' : null">
+      <button *ngIf="data.name && config.getNamedRuleset && config.saveNamedRuleset && config.deleteNamedRuleset" type="button" class="q-name-action" (click)="namedRulesetAction(data)" [ngClass]="getClassNames('button')" [class.q-name-action-modified]="namedRulesetModified(data)" [disabled]="disabled" [title]="namedRulesetModified(data) ? rulesetName + ' has been modified needs to be saved, renamed or unnamed' : null">
         <i [ngClass]="getClassNames(namedRulesetModified(data) ? 'saveIcon' : 'searchIcon')"></i>
         <span class="q-name-label" [ngClass]="{'q-name-modified': namedRulesetModified(data)}">{{data.name}}</span>
       </button>
@@ -182,6 +182,13 @@
           <path d="M1 3h10v2H1zM1 7h10v2H1z"/>
         </svg>
         {{ruleName}}
+      </button>
+      <button *ngIf="allowConvertToRuleset" type="button"
+              (click)="wrapRuleset(data, parentValue)" [title]="'Wrap this ' + rulesetName + ' in another ' + rulesetName" [ngClass]="getClassNames('button')" [disabled]="disabled">
+        <svg [ngClass]="getClassNames('equalIcon')" width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
+          <path d="M1 3h10v2H1zM1 7h10v2H1z"/>
+        </svg>
+        {{rulesetName}}
       </button>
       <ng-container *ngIf="!!parentValue">
         <ng-container *ngTemplateOutlet="_rulesetRemoveButtonTpl"></ng-container>


### PR DESCRIPTION
## Summary
- allow configuring a `defaultRuleAttribute` for newly added rules
- include a wrap ruleset option when converting rulesets
- highlight modified named rulesets with red border and light background
- demo uses the new `defaultRuleAttribute` option

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68704f0e1f44832189fb06c9f8c8d628