### PR TITLE
Add external editor for named queries

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -1,6 +1,9 @@
 import { FormBuilder, FormControl } from '@angular/forms';
 import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { firstValueFrom } from 'rxjs';
 import { QueryBuilderClassNames, QueryBuilderConfig, RuleSet, Rule } from 'ngx-query-builder';
+import { EditRulesetDialogComponent } from './edit-ruleset-dialog.component';
 
 @Component({
   selector: 'app-root',
@@ -241,6 +244,18 @@ export class AppComponent implements OnInit {
     delete this.namedRulesets[name];
   }
 
+  editNamedRuleset(ruleset: RuleSet): Promise<RuleSet | null> {
+    return firstValueFrom(this.dialog.open(EditRulesetDialogComponent, {
+      data: {
+        ruleset: JSON.parse(JSON.stringify(ruleset)),
+        rulesetName: this.rulesetName,
+        validate: (rs: any) => this.validateRuleset(rs)
+      },
+      width: '800px',
+      autoFocus: false
+    }).afterClosed());
+  }
+
   updateNamedRulesetsUsage() {
     if (this.useSavedRulesets) {
       this.currentConfig = {
@@ -248,7 +263,8 @@ export class AppComponent implements OnInit {
         listNamedRulesets: this.listNamedRulesets.bind(this),
         getNamedRuleset: this.getNamedRuleset.bind(this),
         saveNamedRuleset: this.saveNamedRuleset.bind(this),
-        deleteNamedRuleset: this.deleteNamedRuleset.bind(this)
+        deleteNamedRuleset: this.deleteNamedRuleset.bind(this),
+        editNamedRuleset: this.editNamedRuleset.bind(this)
       } as QueryBuilderConfig;
     } else {
       const {
@@ -256,6 +272,7 @@ export class AppComponent implements OnInit {
         getNamedRuleset,
         saveNamedRuleset,
         deleteNamedRuleset,
+        editNamedRuleset,
         ...rest
       } = this.currentConfig as any;
       this.currentConfig = rest;
@@ -270,7 +287,8 @@ export class AppComponent implements OnInit {
   }
 
   constructor(
-    private formBuilder: FormBuilder
+    private formBuilder: FormBuilder,
+    private dialog: MatDialog
   ) {
     this.queryCtrl = this.formBuilder.control(this.query);
     this.currentConfig = this.config;

--- a/projects/ngx-query-builder-demo/src/app/app.module.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.module.ts
@@ -1,7 +1,10 @@
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
 import { AppComponent } from './app.component';
+import { EditRulesetDialogComponent } from './edit-ruleset-dialog.component';
 
 import { QueryBuilderModule } from 'ngx-query-builder';
 
@@ -10,9 +13,11 @@ import { QueryBuilderModule } from 'ngx-query-builder';
     BrowserModule,
     FormsModule,
     ReactiveFormsModule,
+    MatDialogModule,
+    MatButtonModule,
     QueryBuilderModule
   ],
-  declarations: [ AppComponent ],
+  declarations: [ AppComponent, EditRulesetDialogComponent ],
   bootstrap: [ AppComponent ]
 })
 export class AppModule {

--- a/projects/ngx-query-builder-demo/src/app/edit-ruleset-dialog.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/edit-ruleset-dialog.component.ts
@@ -1,0 +1,65 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { RuleSet } from 'ngx-query-builder';
+
+export interface EditRulesetDialogData {
+  ruleset: RuleSet;
+  rulesetName: string;
+  validate: (rs: any) => boolean;
+}
+
+@Component({
+  selector: 'app-edit-ruleset-dialog',
+  template: `
+    <h1 mat-dialog-title>Edit {{data.rulesetName}}</h1>
+    <div mat-dialog-content>
+      <textarea class="output" [ngClass]="state" [(ngModel)]="text" (ngModelChange)="onChange($event)"></textarea>
+    </div>
+    <div mat-dialog-actions>
+      <button mat-button (click)="dialogRef.close()">Cancel</button>
+      <button mat-raised-button color="primary" [disabled]="state !== 'valid'" (click)="save()">Save</button>
+    </div>
+  `,
+  styleUrls: ['./app.component.less']
+})
+export class EditRulesetDialogComponent {
+  text: string;
+  state: 'valid' | 'invalid-json' | 'invalid-query' = 'valid';
+
+  constructor(
+    public dialogRef: MatDialogRef<EditRulesetDialogComponent, RuleSet | null>,
+    @Inject(MAT_DIALOG_DATA) public data: EditRulesetDialogData
+  ) {
+    this.text = JSON.stringify(data.ruleset, null, 2);
+    this.validate();
+  }
+
+  onChange(value: string): void {
+    this.text = value;
+    this.validate();
+  }
+
+  private validate(): void {
+    try {
+      const val = JSON.parse(this.text.trim());
+      if (this.data.validate(val)) {
+        this.state = 'valid';
+      } else {
+        this.state = 'invalid-query';
+      }
+    } catch {
+      this.state = 'invalid-json';
+    }
+  }
+
+  save(): void {
+    try {
+      const val = JSON.parse(this.text.trim());
+      if (this.data.validate(val)) {
+        this.dialogRef.close(val);
+      }
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/projects/ngx-query-builder/src/lib/components/named-ruleset-dialog.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/named-ruleset-dialog.component.ts
@@ -7,10 +7,11 @@ export interface NamedRulesetDialogData {
   allowDelete: boolean;
   modified: boolean;
   rulesetNameSanitizer?: (value: string) => string;
+  allowEdit?: boolean;
 }
 
 export interface NamedRulesetDialogResult {
-  action: 'save' | 'delete' | 'cancel' | 'removeName' | 'undo';
+  action: 'save' | 'delete' | 'cancel' | 'removeName' | 'undo' | 'edit';
   name?: string;
 }
 
@@ -38,6 +39,7 @@ export interface NamedRulesetDialogResult {
     <div mat-dialog-actions>
       <button mat-button (click)="dialogRef.close({action: 'cancel'})">Cancel</button>
       <button mat-button *ngIf="data.modified" (click)="dialogRef.close({action: 'undo'})">Undo</button>
+      <button mat-button *ngIf="data.allowEdit" (click)="dialogRef.close({action: 'edit'})">Edit</button>
       <button mat-raised-button color="primary" [disabled]="isUpdateDisabled()" (click)="dialogRef.close({action: 'save', name})">Update</button>
     </div>
   `

--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1478,6 +1478,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
         rulesetName: this.rulesetName,
         allowDelete: true,
         modified,
+        allowEdit: !!this.config.editNamedRuleset,
         rulesetNameSanitizer: this.config.rulesetNameSanitizer
       }
     }).afterClosed().subscribe((result: NamedRulesetDialogResult | undefined) => {
@@ -1496,6 +1497,21 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
         }
         this.handleTouched();
         this.handleDataChange();
+        return;
+      }
+      if (result.action === 'edit' && this.config.editNamedRuleset) {
+        Promise.resolve(this.config.editNamedRuleset(this.cloneRuleset(ruleset)))
+          .then(edited => {
+            if (edited) {
+              const parent = QueryBuilderComponent.parentMap.get(ruleset) || null;
+              Object.keys(ruleset).forEach(k => delete (ruleset as any)[k]);
+              Object.assign(ruleset, edited);
+              this.registerParentRefs(ruleset, parent);
+              this.saveNamedRulesetDefinition(ruleset);
+            }
+            this.handleTouched();
+            this.handleDataChange();
+          });
         return;
       }
       if (result.action === 'removeName' || !result.name || result.name.trim() === '') {

--- a/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts
+++ b/projects/ngx-query-builder/src/lib/models/query-builder.interfaces.ts
@@ -113,6 +113,7 @@ export interface QueryBuilderConfig {
   getNamedRuleset?: (name: string) => RuleSet;
   saveNamedRuleset?: (ruleset: RuleSet) => void;
   deleteNamedRuleset?: (name: string) => void;
+  editNamedRuleset?: (ruleset: RuleSet) => Promise<RuleSet | null> | RuleSet | null;
   rulesetNameSanitizer?: (value: string) => string;
 }
 


### PR DESCRIPTION
## Summary
- allow named query editing via `editNamedRuleset` callback
- show "Edit" button when callback is present
- handle edit action in query builder component
- demo: popup JSON editor for named query editing

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871486e7d6c8321b95e26529691a3ec