### PR TITLE
Fix module import for standalone dialog

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.module.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.module.ts
@@ -4,13 +4,17 @@ import { BrowserModule } from '@angular/platform-browser';
 import { AppComponent } from './app.component';
 
 import { QueryBuilderModule } from 'ngx-query-builder';
+// The EditRulesetDialogComponent is a standalone component. It should be
+// imported rather than declared to avoid NG6008 errors.
+import { EditRulesetDialogComponent } from './edit-ruleset-dialog.component';
 
 @NgModule({
   imports: [
     BrowserModule,
     FormsModule,
     ReactiveFormsModule,
-    QueryBuilderModule
+    QueryBuilderModule,
+    EditRulesetDialogComponent
   ],
   declarations: [ AppComponent ],
   bootstrap: [ AppComponent ]


### PR DESCRIPTION
## Summary
- import `EditRulesetDialogComponent` for the demo app
- include the standalone dialog in the module `imports`

## Testing
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68714ea826808321ad6d84862c0e5e1e