### PR TITLE
Fix standalone flag for demo dialog

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/edit-ruleset-dialog.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/edit-ruleset-dialog.component.ts
@@ -10,6 +10,7 @@ export interface EditRulesetDialogData {
 
 @Component({
   selector: 'app-edit-ruleset-dialog',
+  standalone: false,
   template: `
     <h1 mat-dialog-title>Edit {{data.rulesetName}}</h1>
     <div mat-dialog-content>


### PR DESCRIPTION
## Summary
- mark the demo `EditRulesetDialogComponent` as `standalone: false`

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871508135b88321b79c121d8fe75a26