### PR TITLE
Fix resizable ruleset dialog

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -252,7 +252,8 @@ export class AppComponent implements OnInit {
         validate: (rs: any) => this.validateRuleset(rs)
       },
       width: '800px',
-      autoFocus: false
+      autoFocus: false,
+      panelClass: 'edit-ruleset-dialog'
     }).afterClosed());
   }
 

--- a/projects/ngx-query-builder-demo/src/styles.less
+++ b/projects/ngx-query-builder-demo/src/styles.less
@@ -2,3 +2,21 @@
 @import '@angular/material/prebuilt-themes/indigo-pink.css';
 
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+
+/* Make the Edit Ruleset dialog resizable and keep the editor fixed */
+.edit-ruleset-dialog .mat-mdc-dialog-container {
+  resize: both;
+  overflow: auto;
+  max-height: none !important;
+}
+
+.edit-ruleset-dialog .mat-mdc-dialog-content {
+  height: 100%;
+}
+
+.edit-ruleset-dialog .output {
+  resize: none;
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- make edit ruleset dialog panel resizable instead of textarea

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871574e7fe8832183cafad10798b6a6