### PR TITLE
Make edit ruleset dialog resizable

### DIFF
--- a/projects/ngx-query-builder-demo/src/app/app.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/app.component.ts
@@ -252,6 +252,7 @@ export class AppComponent implements OnInit {
         validate: (rs: any) => this.validateRuleset(rs)
       },
       width: '800px',
+      panelClass: 'resizable-dialog',
       autoFocus: false
     }).afterClosed());
   }

--- a/projects/ngx-query-builder-demo/src/app/edit-ruleset-dialog.component.less
+++ b/projects/ngx-query-builder-demo/src/app/edit-ruleset-dialog.component.less
@@ -1,0 +1,6 @@
+.dialog-output {
+  width: 100%;
+  height: 100%;
+  resize: none;
+  box-sizing: border-box;
+}

--- a/projects/ngx-query-builder-demo/src/app/edit-ruleset-dialog.component.ts
+++ b/projects/ngx-query-builder-demo/src/app/edit-ruleset-dialog.component.ts
@@ -14,14 +14,14 @@ export interface EditRulesetDialogData {
   template: `
     <h1 mat-dialog-title>Edit {{data.rulesetName}}</h1>
     <div mat-dialog-content>
-      <textarea class="output" [ngClass]="state" [(ngModel)]="text" (ngModelChange)="onChange($event)"></textarea>
+      <textarea class="output dialog-output" [ngClass]="state" [(ngModel)]="text" (ngModelChange)="onChange($event)"></textarea>
     </div>
     <div mat-dialog-actions>
       <button mat-button (click)="dialogRef.close()">Cancel</button>
       <button mat-raised-button color="primary" [disabled]="state !== 'valid'" (click)="save()">Save</button>
     </div>
   `,
-  styleUrls: ['./app.component.less']
+  styleUrls: ['./app.component.less', './edit-ruleset-dialog.component.less']
 })
 export class EditRulesetDialogComponent {
   text: string;

--- a/projects/ngx-query-builder-demo/src/styles.less
+++ b/projects/ngx-query-builder-demo/src/styles.less
@@ -2,3 +2,14 @@
 @import '@angular/material/prebuilt-themes/indigo-pink.css';
 
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+
+.cdk-overlay-pane.resizable-dialog {
+  resize: both;
+  overflow: auto;
+}
+
+.cdk-overlay-pane.resizable-dialog .mat-dialog-container {
+  max-width: none;
+  max-height: none;
+  height: 100%;
+}


### PR DESCRIPTION
## Summary
- allow the edit ruleset dialog to be resized
- add a custom stylesheet for the dialog
- open the dialog with a resizable panel class

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm run test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68715a0f04148321a07601cd60a9ea1c